### PR TITLE
refactor insecure gate

### DIFF
--- a/ui/src/components/ConnectionModal.tsx
+++ b/ui/src/components/ConnectionModal.tsx
@@ -15,13 +15,17 @@ interface ConnectionModalProps {
  * Connection gate modal, two variants (see useConnectionGate):
  *
  * - offline: a network-dependent action was attempted while the OS reports
- *   no connection at all (`navigator.onLine === false`).
- * - insecure: the internet is up but the HTTPS probe to TONE3000 failed,
- *   usually a wrong system clock, so we offer a jump to the OS date & time
- *   settings where the native side provides one.
+ *   no connection at all (`navigator.onLine === false`). The action is
+ *   queued and "Try again" re-runs it.
+ * - insecure: a background probe confirmed (twice) that HTTPS to TONE3000
+ *   fails while the OS reports a connection (usually a wrong system clock),
+ *   so we offer a jump to the OS date & time settings where the native side
+ *   provides one. Purely diagnostic: the triggering action already ran and
+ *   failed on its own recovery paths.
  *
  * Same full-window scrim + button language as OAuthOverlay so the error
- * surfaces read as one system.
+ * surfaces read as one system. Rendered after OAuthOverlay at the same
+ * z-index, so the diagnosis stacks above a stranded OAuth page.
  */
 export const ConnectionModal: React.FC<ConnectionModalProps> = ({
   problem,
@@ -64,9 +68,9 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
       <div style={{ fontSize: '14rem', fontWeight: 400, opacity: 0.95, maxWidth: '400rem' }}>
         {offline
           ? 'No internet connection. Connect to browse and load tones from TONE3000.'
-          : "Couldn't establish a secure connection to TONE3000. This usually means the " +
-            "computer's date & time are wrong; a firewall, VPN, or security software can " +
-            'also cause it.'}
+          : "Couldn't make a secure connection to TONE3000. If other sites work on this " +
+            'computer, the usual cause is a wrong date & time; a firewall, VPN, or ' +
+            'security software can also block the plugin.'}
       </div>
       <div style={{ display: 'flex', gap: '12rem' }}>
         <button type="button" onClick={onRetry} style={filledPillButtonStyle}>

--- a/ui/src/components/Plugin.tsx
+++ b/ui/src/components/Plugin.tsx
@@ -173,12 +173,13 @@ export const Plugin: React.FC = () => {
   );
 
   // First line of defence for network-dependent actions: an instant
-  // `navigator.onLine` check (no probe, no latency at click time) plus the
-  // cached result of the startup TLS probe, which stops OAuth from navigating
-  // the webview into an unrecoverable page when HTTPS is broken (wrong system
-  // clock, intercepting proxy). A connected-but-dead network still gets
-  // through and lands on the recovery paths (failed-navigation recovery,
-  // stream retry, block retry).
+  // `navigator.onLine` check (no probe, no latency at click time). Actions
+  // are never blocked beyond that: a throttled background probe verifies
+  // HTTPS to TONE3000 on the side and, only after a confirming re-probe,
+  // explains a broken-TLS environment (wrong system clock, intercepting
+  // proxy) that would otherwise strand OAuth on a dead page. Failures still
+  // land on the recovery paths (failed-navigation recovery, stream retry,
+  // block retry).
   const connectionGate = useConnectionGate();
   const { requireConnection } = connectionGate;
 
@@ -584,7 +585,8 @@ export const Plugin: React.FC = () => {
         />
 
         {/* Connection gate for internet-dependent actions (add / swap /
-          login / select) and the startup TLS probe result. */}
+          login / select). Offline gates instantly; TLS problems surface from
+          a non-blocking background probe, only after confirmation. */}
         <ConnectionModal
           problem={connectionGate.problem}
           onRetry={connectionGate.retry}

--- a/ui/src/hooks/useConnectionGate.ts
+++ b/ui/src/hooks/useConnectionGate.ts
@@ -1,5 +1,20 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { T3K_API } from '../t3k/config';
+
+/**
+ * Probe timeout. Nothing user-visible ever waits on a probe, so this only
+ * bounds how long the background check can stay in flight.
+ */
+const PROBE_TIMEOUT_MS = 8000;
+
+/** Minimum gap between background probes; retry bypasses it. */
+const PROBE_TTL_MS = 30_000;
+
+/**
+ * Gap before the confirmation probe. One transient failure (DAW startup
+ * contention, Wi-Fi renegotiating after wake) must not raise the alarm.
+ */
+const CONFIRM_DELAY_MS = 2000;
 
 /**
  * Instant connectivity check via `navigator.onLine`. `false` means the OS has
@@ -13,24 +28,45 @@ function checkInternet(): boolean {
 }
 
 /**
+ * - ok: the TLS handshake with the TONE3000 origin completed.
+ * - insecure: the fetch failed at the network layer (DNS, refused, TLS).
+ * - inconclusive: timeout or an unexpected error; no evidence either way.
+ */
+type ProbeResult = 'ok' | 'insecure' | 'inconclusive';
+
+/**
  * One HTTPS reachability probe against the TONE3000 origin. OAuth navigates
  * this same webview to tone3000.com, and when TLS is broken (wrong system
  * clock, intercepting proxy or security software) that navigation strands the
- * webview on a dead page. So we probe once at startup and gate on the cached
- * result instead of probing at click time. `no-cors` because only the TLS
- * handshake matters, not the response.
+ * webview on a dead page. The probe exists to explain that failure, not to
+ * prevent it. `no-cors` because only the TLS handshake matters, not the
+ * response.
+ *
+ * The timeout is built from AbortController + setTimeout instead of
+ * `AbortSignal.timeout()`: the system WebKit on older macOS lacks the latter,
+ * and a TypeError thrown by a missing API must never read as a broken
+ * connection. Never throws.
  */
-async function probeSecureConnection(): Promise<boolean> {
+async function probeSecureConnection(): Promise<ProbeResult> {
+  const controller = typeof AbortController === 'undefined' ? undefined : new AbortController();
+  const timer = controller ? setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS) : undefined;
   try {
     await fetch(T3K_API, {
       method: 'HEAD',
       mode: 'no-cors',
       cache: 'no-store',
-      signal: AbortSignal.timeout(5000),
+      signal: controller?.signal,
     });
-    return true;
-  } catch {
-    return false;
+    return 'ok';
+  } catch (err) {
+    // Our own timeout firing: a slow network, not evidence about TLS.
+    if ((err as { name?: string } | null)?.name === 'AbortError') return 'inconclusive';
+    // fetch reports network-layer failures (DNS, connection refused, TLS
+    // rejection) as TypeError. Anything else is an environment/programming
+    // error and must stay silent.
+    return err instanceof TypeError ? 'insecure' : 'inconclusive';
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -46,54 +82,83 @@ export type ConnectionProblem = 'offline' | 'insecure';
  *   <ConnectionModal problem={gate.problem}
  *                    onRetry={gate.retry} onDismiss={gate.dismiss} />
  *
- * `requireConnection` runs the action when the OS reports a connection and
- * the startup TLS probe didn't fail; otherwise it opens the matching modal
- * variant. "Try again" re-checks (re-probing TLS if that's what failed) and
- * runs the original action on success.
+ * `requireConnection` is non-blocking by design. If the OS reports no
+ * connection at all, the offline modal opens and the action is queued for
+ * "Try again" (instant, no probe). Otherwise the action runs immediately and
+ * a throttled background probe verifies HTTPS to TONE3000 on the side;
+ * nothing ever waits on a probe.
  *
- * A failed probe while offline stays silent: offline use is normal and
- * already handled at action time. The modal only appears when the internet
- * is up but a secure connection is refused.
+ * The insecure modal is diagnostic, not a gate: it appears only after two
+ * consecutive network-layer failures while the OS still reports a
+ * connection, by which point the triggering action has already failed on its
+ * own recovery paths and the modal explains why. Timeouts count as
+ * inconclusive and never alarm, and a later successful probe (or retry)
+ * closes the modal, so a transient blip can't leave a stale warning behind.
  */
 export function useConnectionGate() {
   const [problem, setProblem] = useState<ConnectionProblem | null>(null);
+  // Queued action for the offline modal only; "Try again" re-runs it.
   const pendingActionRef = useRef<(() => void | Promise<void>) | null>(null);
-  // Known-bad TLS from the last probe; only ever set while online.
-  const insecureRef = useRef(false);
+  const probingRef = useRef(false);
+  const lastProbeAtRef = useRef(0);
 
-  useEffect(() => {
-    let cancelled = false;
-    void probeSecureConnection().then((ok) => {
-      if (cancelled || ok || !checkInternet()) return;
-      insecureRef.current = true;
-      setProblem('insecure');
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const requireConnection = useCallback((action: () => void | Promise<void>) => {
-    if (!checkInternet()) {
-      pendingActionRef.current = action;
-      setProblem('offline');
-    } else if (insecureRef.current) {
-      pendingActionRef.current = action;
-      setProblem('insecure');
-    } else {
-      pendingActionRef.current = null;
-      setProblem(null);
-      void action();
+  /**
+   * Fire-and-forget verification. Throttled unless forced (retry button);
+   * a first "insecure" result is re-checked before surfacing the modal.
+   */
+  const verifyInBackground = useCallback(async (force = false) => {
+    if (probingRef.current) return;
+    if (!force && Date.now() - lastProbeAtRef.current < PROBE_TTL_MS) return;
+    probingRef.current = true;
+    try {
+      let result = await probeSecureConnection();
+      if (result === 'insecure') {
+        await new Promise((resolve) => setTimeout(resolve, CONFIRM_DELAY_MS));
+        result = await probeSecureConnection();
+      }
+      if (result === 'ok') {
+        // Auto-heal: never leave a stale warning up once TLS works again.
+        setProblem((p) => (p === 'insecure' ? null : p));
+      } else if (result === 'insecure' && checkInternet()) {
+        // Don't replace an open offline modal (and its queued action).
+        setProblem((p) => (p === null ? 'insecure' : p));
+      }
+      // Inconclusive results stay silent: no evidence, no alarm.
+    } finally {
+      probingRef.current = false;
+      lastProbeAtRef.current = Date.now();
     }
   }, []);
 
+  const requireConnection = useCallback(
+    (action: () => void | Promise<void>) => {
+      if (!checkInternet()) {
+        pendingActionRef.current = action;
+        setProblem('offline');
+        return;
+      }
+      pendingActionRef.current = null;
+      void action();
+      void verifyInBackground();
+    },
+    [verifyInBackground]
+  );
+
   const retry = useCallback(async () => {
-    if (insecureRef.current && checkInternet())
-      insecureRef.current = !(await probeSecureConnection());
     const action = pendingActionRef.current;
-    if (action) requireConnection(action);
-    else if (checkInternet() && !insecureRef.current) setProblem(null);
-  }, [requireConnection]);
+    if (action) {
+      // Offline modal: re-check the OS flag and release the queued action.
+      if (checkInternet()) {
+        pendingActionRef.current = null;
+        setProblem(null);
+        void action();
+        void verifyInBackground();
+      }
+      return;
+    }
+    // Insecure modal: force a fresh probe; auto-heal closes it on success.
+    await verifyInBackground(true);
+  }, [verifyInBackground]);
 
   const dismiss = useCallback(() => {
     pendingActionRef.current = null;


### PR DESCRIPTION
## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [x] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [x] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [x] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [x] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [x] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [x] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [x] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [x] README / `plugin/docs/` updated if the public build or behavior changed
