### PR TITLE
fix installer Rosetta prompt on Apple Silicon (#37)

### DIFF
--- a/script/create-pkg.sh
+++ b/script/create-pkg.sh
@@ -254,7 +254,11 @@ RES="$INSTALLER_DIR/Resources"
   echo '<?xml version="1.0" encoding="utf-8"?>'
   echo '<installer-gui-script minSpecVersion="2">'
   echo "  <title>TONE3000 ${VERSION}</title>"
-  echo '  <options customize="always" allow-external-scripts="no" rootVolumeOnly="false" />'
+  # hostArchitectures: without arm64 listed, Installer.app on Apple Silicon
+  # evaluates the distribution under Rosetta 2 and prompts to install it
+  # (issue #37). productbuild only injects this default when it synthesizes
+  # the XML itself; a hand-written --distribution file must declare it.
+  echo '  <options customize="always" allow-external-scripts="no" rootVolumeOnly="false" hostArchitectures="arm64,x86_64" />'
   echo '  <domains enable_localSystem="true" />'
 
   # Branding: a logo-only image (transparent elsewhere) anchored bottom-left


### PR DESCRIPTION
## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
