### PR TITLE
Old webkit boot

### DIFF
--- a/script/create-pkg.sh
+++ b/script/create-pkg.sh
@@ -255,9 +255,9 @@ RES="$INSTALLER_DIR/Resources"
   echo '<installer-gui-script minSpecVersion="2">'
   echo "  <title>TONE3000 ${VERSION}</title>"
   # hostArchitectures: without arm64 listed, Installer.app on Apple Silicon
-  # evaluates the distribution under Rosetta 2 and prompts to install it
-  # (issue #37). productbuild only injects this default when it synthesizes
-  # the XML itself; a hand-written --distribution file must declare it.
+  # evaluates the distribution under Rosetta 2 and prompts to install it.
+  # productbuild only injects this default when it synthesizes the XML
+  # itself; a hand-written --distribution file must declare it.
   echo '  <options customize="always" allow-external-scripts="no" rootVolumeOnly="false" hostArchitectures="arm64,x86_64" />'
   echo '  <domains enable_localSystem="true" />'
 

--- a/script/create-pkg.sh
+++ b/script/create-pkg.sh
@@ -254,7 +254,11 @@ RES="$INSTALLER_DIR/Resources"
   echo '<?xml version="1.0" encoding="utf-8"?>'
   echo '<installer-gui-script minSpecVersion="2">'
   echo "  <title>TONE3000 ${VERSION}</title>"
-  echo '  <options customize="always" allow-external-scripts="no" rootVolumeOnly="false" />'
+  # hostArchitectures: without arm64 listed, Installer.app on Apple Silicon
+  # evaluates the distribution under Rosetta 2 and prompts to install it
+  # (issue #37). productbuild only injects this default when it synthesizes
+  # the XML itself; a hand-written --distribution file must declare it.
+  echo '  <options customize="always" allow-external-scripts="no" rootVolumeOnly="false" hostArchitectures="arm64,x86_64" />'
   echo '  <domains enable_localSystem="true" />'
 
   # Branding: a logo-only image (transparent elsewhere) anchored bottom-left

--- a/ui/README.md
+++ b/ui/README.md
@@ -21,6 +21,11 @@ The dev server is useful for layout and TONE3000 browsing work, but anything
 that calls into the plugin (parameters, chain state, meters) needs the real
 JUCE backend, so the usual loop is `npm run build` followed by a plugin build.
 
+The bundle must stay runnable on old system WebKits (macOS 10.15 is Safari
+13-15 era, Linux WebKitGTK varies by distro), so `vite.config.ts` pins
+`build.target` low; don't raise it casually. If the UI ever fails to boot,
+the watchdog in `index.html` writes the reason to the plugin's native log.
+
 ## How it talks to the plugin
 
 `@juce-framework/webview` (from the JUCE tree in `../libs`) provides three

--- a/ui/index.html
+++ b/ui/index.html
@@ -12,6 +12,40 @@
         padding: 0;
       }
     </style>
+    <script>
+      // Boot watchdog. Classic script, ES5-only syntax: it must parse on any
+      // WebKit, because its job is reporting when main.js cannot.
+      //
+      // A module script that fails to parse or load errors on its <script>
+      // element, not window.onerror, so a failed boot would otherwise leave
+      // a black window and an empty log. Capture resource errors here, and
+      // if the bundle hasn't flagged itself booted (window.__T3K_UI_BOOTED,
+      // set by main.tsx) shortly after load, log one line of feature probes:
+      // the native shim forwards console output to the on-disk log, so a
+      // black-window report says exactly what this engine is missing.
+      (function () {
+        window.addEventListener('error', function (e) {
+          var t = e && e.target;
+          if (t && (t.tagName === 'SCRIPT' || t.tagName === 'LINK')) {
+            console.error('[boot] resource failed to load: ' + (t.src || t.href));
+          }
+        }, true);
+        function probe(src) {
+          try { eval(src); return 'yes'; } catch (err) { return 'no'; }
+        }
+        setTimeout(function () {
+          if (window.__T3K_UI_BOOTED) return;
+          console.error(
+            '[boot] UI did not boot within 4s. WebKit probes:' +
+            ' optional-chaining=' + probe('null?.x') +
+            ' class-fields=' + probe('(class{x=1})') +
+            ' static-blocks=' + probe('(class{static{}})') +
+            ' AbortSignal.timeout=' + (typeof AbortSignal !== 'undefined' && AbortSignal.timeout ? 'yes' : 'no') +
+            ' UA=' + navigator.userAgent
+          );
+        }, 4000);
+      })();
+    </script>
   </head>
   <body style="background-color: #000000;">
     <div id="root"></div>

--- a/ui/src/hooks/useUpdateNotice.ts
+++ b/ui/src/hooks/useUpdateNotice.ts
@@ -110,13 +110,25 @@ export function useUpdateNotice(client: T3KClient): {
         if (typeof id === 'string') deviceId = id;
       }
 
-      const res = await client.fetchPluginVersion({
-        signal: AbortSignal.timeout(5000),
-        // The response is CDN-cached server-side; never let a stale local
-        // webview cache hide a new release for days.
-        cache: 'no-cache',
-        headers: deviceId ? { 'X-Device-Id': deviceId } : undefined,
-      });
+      // AbortController + setTimeout instead of `AbortSignal.timeout()`: the
+      // system WebKit before Safari 16 (any macOS 10.15 install) lacks the
+      // latter, and the machines running old WebKit are exactly the ones
+      // that most need to hear about updates (same rationale as
+      // probeSecureConnection in useConnectionGate).
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 5000);
+      let res: Response;
+      try {
+        res = await client.fetchPluginVersion({
+          signal: controller.signal,
+          // The response is CDN-cached server-side; never let a stale local
+          // webview cache hide a new release for days.
+          cache: 'no-cache',
+          headers: deviceId ? { 'X-Device-Id': deviceId } : undefined,
+        });
+      } finally {
+        clearTimeout(timer);
+      }
       if (!res.ok) return;
 
       const body: unknown = await res.json();

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -8,6 +8,11 @@ import '@fontsource/roboto-mono/400.css';
 import '@fontsource/roboto-mono/700.css';
 import './index.css';
 
+// Reaching this line means the bundle parsed and executed: tell the boot
+// watchdog in index.html, which otherwise logs boot diagnostics to the
+// native log after 4s (see the inline script there).
+window.__T3K_UI_BOOTED = true;
+
 // A file dropped anywhere on the plugin would make the webview navigate away
 // from the UI. Swallow drags globally; components that want drops can handle
 // them before the event bubbles here.

--- a/ui/src/vite-env.d.ts
+++ b/ui/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface Window {
+  /**
+   * Set by main.tsx the moment the bundle executes; read by the boot
+   * watchdog inline in index.html. If it never appears, the watchdog logs
+   * WebKit feature probes to the forwarded console (-> TONE3000.log).
+   */
+  __T3K_UI_BOOTED?: boolean;
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -6,6 +6,14 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   build: {
+    // The plugin webview runs the system WebKit on macOS and Linux, which
+    // can be years old (macOS 10.15 tops out at Safari 15.6, or 13.x if
+    // Safari was never updated). Vite's default target assumes a current
+    // browser, and one construct it leaves untranspiled is a parse error
+    // that kills the whole bundle before it runs: a silent black window.
+    // safari13 keeps the bundle parseable on every supported WebKit; the
+    // runtime floor is Safari 13.1 (ResizeObserver), macOS 10.15.4.
+    target: ['safari13'],
     outDir: '../plugin/webview',
     emptyOutDir: true,
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary

Vite 7 defaults to a Safari 16 target, so the bundle shipped syntax that
pre-14.1 WebKit can't parse, and a module parse error never reaches
window.onerror: a black window and an empty log. Pin build.target to
safari13, replace AbortSignal.timeout (Safari 16+) in the update check
with AbortController + setTimeout, and add an ES5 boot watchdog to
index.html that logs syntax probes to the native log when the bundle
never boots, so future black-window reports self-diagnose.

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [x] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [x] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [x] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [x] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [x] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [x] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [x] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [x] README / `plugin/docs/` updated if the public build or behavior changed
