### PR TITLE
fix horizontal scrolling with a vertical-only mouse wheel (#26)

### DIFF
--- a/ui/src/components/ChainView.tsx
+++ b/ui/src/components/ChainView.tsx
@@ -25,6 +25,7 @@ import {
   gapCenterX,
 } from './GalleryLane';
 import { useChainActions } from '../hooks/useChainActions';
+import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll';
 import { FONT_MONO, WHITE } from './theme';
 import type { ChainBranch, ChainItem, ChainSide, ToneBlock } from '../types/chain';
 import { isInsertSlot } from '../types/chain';
@@ -117,6 +118,7 @@ export const ChainView: React.FC<ChainViewProps> = ({
   returnToGallery = 0,
 }) => {
   const actions = useChainActions();
+  const wheelScrollRef = useHorizontalWheelScroll<HTMLDivElement>();
   // Persisted so the detail takeover survives this component unmounting: a
   // swap from the detail view opens the tone browser (which replaces the whole
   // chain view, and may bounce through the tone3000.com OAuth redirect). The
@@ -467,6 +469,7 @@ export const ChainView: React.FC<ChainViewProps> = ({
             </span>
           )}
           <div
+            ref={wheelScrollRef}
             className="hide-scrollbar"
             style={{
               flex: 1,

--- a/ui/src/components/ToneBrowser.tsx
+++ b/ui/src/components/ToneBrowser.tsx
@@ -11,6 +11,7 @@ import { GearIcon, ToneImage } from './GearIcon';
 import { BusyOverlay, LoadingDots } from './LoadingDots';
 import { HELP, helpProps } from './helpText';
 import { EdgeFade, EDGE_FADE_WIDTH } from './GalleryLane';
+import { useHorizontalWheelScroll } from '../hooks/useHorizontalWheelScroll';
 import { CARD_WIDTH } from './chainLayout';
 import { T3kMark } from './T3kMark';
 import {
@@ -198,45 +199,49 @@ const GearFilterPill: React.FC<{
 const GearFilterRow: React.FC<{ active: string | null; onChange: (id: string | null) => void }> = ({
   active,
   onChange,
-}) => (
-  <div
-    style={{
-      position: 'relative',
-      marginLeft: `-${EDGE_FADE_WIDTH}rem`,
-      marginRight: `-${EDGE_FADE_WIDTH}rem`,
-    }}
-  >
+}) => {
+  const wheelScrollRef = useHorizontalWheelScroll<HTMLDivElement>();
+  return (
     <div
-      role="radiogroup"
-      aria-label="Filter by gear type"
-      className="hide-scrollbar"
       style={{
-        display: 'flex',
-        gap: '10rem',
-        overflowX: 'auto',
-        // overflow-x:auto also clips vertically at the scrollport, and at
-        // fractional UI scales the pill height can round a subpixel taller
-        // than the row, shaving the bottom border. The vertical padding
-        // gives the pills breathing room inside the scrollport; the negative
-        // margins cancel it outside so the surrounding layout is unchanged.
-        padding: `2rem ${EDGE_FADE_WIDTH}rem`,
-        margin: '-2rem 0',
+        position: 'relative',
+        marginLeft: `-${EDGE_FADE_WIDTH}rem`,
+        marginRight: `-${EDGE_FADE_WIDTH}rem`,
       }}
     >
-      {GEAR_FILTERS.map((g) => (
-        <GearFilterPill
-          key={g.id}
-          id={g.id}
-          label={g.label}
-          active={active === g.id}
-          onClick={() => onChange(active === g.id ? null : g.id)}
-        />
-      ))}
+      <div
+        ref={wheelScrollRef}
+        role="radiogroup"
+        aria-label="Filter by gear type"
+        className="hide-scrollbar"
+        style={{
+          display: 'flex',
+          gap: '10rem',
+          overflowX: 'auto',
+          // overflow-x:auto also clips vertically at the scrollport, and at
+          // fractional UI scales the pill height can round a subpixel taller
+          // than the row, shaving the bottom border. The vertical padding
+          // gives the pills breathing room inside the scrollport; the negative
+          // margins cancel it outside so the surrounding layout is unchanged.
+          padding: `2rem ${EDGE_FADE_WIDTH}rem`,
+          margin: '-2rem 0',
+        }}
+      >
+        {GEAR_FILTERS.map((g) => (
+          <GearFilterPill
+            key={g.id}
+            id={g.id}
+            label={g.label}
+            active={active === g.id}
+            onClick={() => onChange(active === g.id ? null : g.id)}
+          />
+        ))}
+      </div>
+      <EdgeFade side="left" />
+      <EdgeFade side="right" />
     </div>
-    <EdgeFade side="left" />
-    <EdgeFade side="right" />
-  </div>
-);
+  );
+};
 
 /** Centered sign-in prompt: shown in place of a gated stream's content while
     signed out, and as a discovery footer under the (public) Trending feed.


### PR DESCRIPTION
## Summary

map a dominantly-vertical wheel to scrollLeft on the chain gallery and gear filter row; native horizontal deltas and shift+wheel keep their built-in handling.

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [x] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
