### PR TITLE
fix IR temp files leaking into the OS temp folder (#25)

### DIFF
--- a/plugin/include/ChainBlock.h
+++ b/plugin/include/ChainBlock.h
@@ -167,7 +167,6 @@ struct ChainBlock {
   // default mix. Long = reverb-like: no pad (diffuse kernels sit at ≈ dry
   // level at unit energy), 50% default mix. Shipped to the UI as `irLong`.
   bool irIsLong{false};
-  juce::File irTempFile;
   juce::LinearSmoothedValue<float> irNormalizationSmoother;
   float irNormalizationGainLinear{1.0f};
 

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -97,6 +97,15 @@ public:
   // Age out local-model stash files unused for a week (runs once per
   // process, off-thread). Called from the constructor.
   static void cleanLocalModelStash();
+  // Sweep "*_ir.wav" files leaked into the OS temp dir by older builds (the
+  // IR loader wrote one per engine build and never deleted it; it now cleans
+  // up after itself). Runs once per process, off-thread. Called from the
+  // constructor.
+  static void cleanLeakedIrTempFiles();
+  // The sweep itself: deletes "*_ir.wav" files in `tempDir` untouched for
+  // over an hour (the age guard protects a concurrent instance's in-flight
+  // file). Returns how many files it deleted.
+  static int sweepLeakedIrTempFiles(const juce::File& tempDir);
   // Replace the tone of an existing block in place. Keeps the block's chain
   // position and user params (enabled/gains/mix); the new tone's first model
   // is queued for background loading.
@@ -437,7 +446,6 @@ private:
     int irNumChannels = 1;
     int irLengthBaseSamples = 0;  // base-rate kernel length (tail reporting)
     bool irIsLong = false;        // short/long classification (see ChainBlock.h)
-    juce::File irTempFile;
     float irNormalizationGainLinear = 1.0f;
   };
 

--- a/plugin/src/Processor.cpp
+++ b/plugin/src/Processor.cpp
@@ -49,9 +49,10 @@ TONE3000Processor::TONE3000Processor()
 
   resolveParamRefs();
 
-  // Age out unused drop-loaded model stash files (no-op after the process's
-  // first instance).
+  // Age out unused drop-loaded model stash files and sweep IR temp files
+  // leaked by older builds (both no-ops after the process's first instance).
   cleanLocalModelStash();
+  cleanLeakedIrTempFiles();
 
   // Oversampling settings apply through a message-thread bounce (see
   // applyOversamplingSettings); the relays can fire from any thread.

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -372,6 +372,38 @@ void TONE3000Processor::cleanLocalModelStash() {
   });
 }
 
+void TONE3000Processor::cleanLeakedIrTempFiles() {
+  // Runs once per process, off the constructor's thread (it does directory
+  // IO), same pattern as cleanLocalModelStash.
+  static std::once_flag once;
+  std::call_once(once, [] {
+    juce::Thread::launch([] {
+      const int removed =
+          sweepLeakedIrTempFiles(juce::File::getSpecialLocation(juce::File::tempDirectory));
+      if (removed > 0)
+        juce::Logger::writeToLog("[ModelLoader] Swept " + juce::String(removed) +
+                                 " leaked IR temp file(s)");
+    });
+  });
+}
+
+int TONE3000Processor::sweepLeakedIrTempFiles(const juce::File& tempDir) {
+  // Builds through v0.0.2 wrote one "<uuid>_ir.wav" per IR engine build into
+  // the OS temp dir and never deleted it (github issue #25: hundreds of MB
+  // after a session of preset browsing). The loader now scopes its temp file
+  // to the engine build (see prepareBlockModelOffThread), so anything
+  // matching the pattern is that legacy bloat or a crash leftover. Nothing
+  // ever reads these files after the build, so deleting them is safe even
+  // under a running older build; the hour of grace covers the only live
+  // window, a concurrent instance mid-build, whose file is seconds old.
+  const juce::Time cutoff = juce::Time::getCurrentTime() - juce::RelativeTime::hours(1);
+  int removed = 0;
+  for (const auto& file : tempDir.findChildFiles(juce::File::findFiles, false, "*_ir.wav"))
+    if (file.getLastModificationTime() < cutoff && file.deleteFile())
+      ++removed;
+  return removed;
+}
+
 void TONE3000Processor::refreshLocalStashCopy(const juce::String& modelUrl,
                                               const std::vector<uint8_t>& bytes) {
   const juce::URL url(modelUrl);
@@ -585,11 +617,17 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
       out.success = true;
     } else {
       // IRs go through the JUCE convolution/format-reader API, which wants a
-      // file. Use a UUID-only leaf name (plus the right extension) so the
-      // model's display name (which may contain characters that are illegal
-      // in file names) never ends up in the path.
-      juce::File tempFile = juce::File::getSpecialLocation(juce::File::tempDirectory)
-                                .getChildFile(juce::Uuid().toString() + "_ir.wav");
+      // file. The TemporaryFile's random leaf name (plus the right extension)
+      // keeps the model's display name (which may contain characters that are
+      // illegal in file names) out of the path, and its destructor deletes
+      // the file on every exit path (success, early return, exception).
+      // Nothing needs the file after this scope: loadImpulseResponse copies
+      // the bytes into memory when prepare() drains the convolver's queue,
+      // and later re-prepares rebuild from that copy, never from the file.
+      // (Files leaked here by older builds are swept at startup, see
+      // cleanLeakedIrTempFiles.)
+      const juce::TemporaryFile scopedIrFile("_ir.wav");
+      const juce::File& tempFile = scopedIrFile.getFile();
 
       if (!tempFile.replaceWithData(modelData.data(), modelData.size())) {
         juce::Logger::writeToLog("[ModelLoader] Failed to create temporary IR file: " +
@@ -612,7 +650,6 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
 
       if (!reader) {
         juce::Logger::writeToLog("[ModelLoader] Failed to read IR file: " + filename);
-        tempFile.deleteFile();
         return out;
       }
 
@@ -709,7 +746,6 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
       out.irNumChannels = irNumChannels;
       out.irLengthBaseSamples = irLengthBaseSamples;
       out.irIsLong = irLengthBaseSamples > kShortIrMaxBaseSamples;
-      out.irTempFile = tempFile;
       out.irNormalizationGainLinear = computeIrNormalizationGain(tempFile, maxIrFileSamples);
 
       juce::Logger::writeToLog(
@@ -970,7 +1006,6 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     block.irNumChannels = 1;
     block.irLengthBaseSamples = 0;
     block.irIsLong = false;
-    block.irTempFile = juce::File();
 
     // Re-assert the block's A2 size in case it changed while this engine
     // was downloading/preparing (a no-op retier when it didn't).
@@ -989,8 +1024,6 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     block.irNumChannels = prepared.irNumChannels;
     block.irLengthBaseSamples = prepared.irLengthBaseSamples;
     block.irIsLong = prepared.irIsLong;
-    block.irTempFile = prepared.irTempFile;
-    prepared.irTempFile = juce::File();
 
     // The base-rate island around the convolvers: blocks added mid-session
     // were never seen by prepareChain, so (re)prepare it here with the same

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,6 +21,7 @@ target_sources(DspTests PRIVATE
     src/clipboard_tests.cpp
     src/dsp_tests.cpp
     src/duplicate_tests.cpp
+    src/ir_temp_file_tests.cpp
     src/local_load_tests.cpp
     src/midi_map_tests.cpp
     src/multicore_tests.cpp

--- a/test/src/ir_temp_file_tests.cpp
+++ b/test/src/ir_temp_file_tests.cpp
@@ -1,0 +1,145 @@
+// IR loader temp-file hygiene (github issue #25). Every IR engine build
+// round-trips the model bytes through a "*_ir.wav" file in the OS temp dir;
+// builds through v0.0.2 never deleted it, leaving hundreds of MB behind after
+// a session of preset browsing. Pins that (a) loads clean up after
+// themselves, on success and on failure, and (b) the startup sweep removes
+// older builds' leftovers without touching in-flight or foreign files.
+
+#include "chain_test_helpers.h"
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <set>
+#include <vector>
+
+namespace {
+
+juce::File osTempDir() { return juce::File::getSpecialLocation(juce::File::tempDirectory); }
+
+// Leaf names of every "*_ir.wav" in the OS temp dir: the loader's file
+// pattern, old (uuid) and new (TemporaryFile) naming alike.
+std::set<juce::String> irTempLeaves() {
+  std::set<juce::String> names;
+  for (const auto& f : osTempDir().findChildFiles(juce::File::findFiles, false, "*_ir.wav"))
+    names.insert(f.getFileName());
+  return names;
+}
+
+// True once no "*_ir.wav" beyond `before` remains in the OS temp dir. A
+// leaked file sits there forever, so waiting out transients (another test
+// process mid-load) can never mask a real leak; on timeout the stragglers
+// are reported by name.
+bool noNewIrTempFilesSettle(const std::set<juce::String>& before, int timeoutMs = 10000) {
+  const auto deadline = juce::Time::getMillisecondCounter() + static_cast<juce::uint32>(timeoutMs);
+  for (;;) {
+    std::vector<juce::String> added;
+    for (const auto& name : irTempLeaves())
+      if (before.count(name) == 0)
+        added.push_back(name);
+    if (added.empty())
+      return true;
+    if (juce::Time::getMillisecondCounter() >= deadline) {
+      for (const auto& name : added)
+        ADD_FAILURE() << "leaked IR temp file: " << name.toStdString();
+      return false;
+    }
+    juce::Thread::sleep(50);
+  }
+}
+
+// Restore a mono chain of the given blocks through the real state path.
+void restoreMonoChain(ChainTestProcessor& proc, std::initializer_list<juce::ValueTree> blocks) {
+  juce::ValueTree state("ChainSnapshot");
+  state.setProperty("stereoEnabled", false, nullptr);
+  juce::ValueTree lane("ChainBlocks");
+  for (const auto& block : blocks)
+    lane.appendChild(block, nullptr);
+  state.appendChild(lane, nullptr);
+  state.appendChild(juce::ValueTree("RightChainBlocks"), nullptr);
+  proc.restoreFromTree(state);
+}
+
+// An IR block whose ModelCache holds unreadable bytes: the loader writes
+// them to its temp file, fails to open a reader, and must still clean up.
+juce::ValueTree makeJunkIrBlockTree(const juce::String& blockId, int toneId, int modelId) {
+  juce::ValueTree block = makeIrBlockTree(blockId, toneId, modelId);
+  juce::MemoryBlock junk(256);
+  junk.fillWith(0x5a);  // no RIFF header, so no WAV reader will open it
+  block.getChildWithName("ModelCache").getChild(0).setProperty("data", juce::var(junk), nullptr);
+  return block;
+}
+
+// Wait until the block reports loadFailed through the UI-facing chain state.
+bool waitForBlockLoadFailed(TONE3000Processor& proc, const juce::String& blockId,
+                            int timeoutMs = 20000) {
+  const auto deadline = juce::Time::getMillisecondCounter() + static_cast<juce::uint32>(timeoutMs);
+  while (juce::Time::getMillisecondCounter() < deadline) {
+    const juce::var state = proc.getChainState(-1);
+    if (const auto* lane = state["chain"].getArray())
+      for (const auto& item : *lane)
+        if (item["blockId"].toString() == blockId && static_cast<bool>(item["loadFailed"]))
+          return true;
+    juce::Thread::sleep(20);
+  }
+  return false;
+}
+
+}  // namespace
+
+TEST(IrTempFileTest, SuccessfulIrLoadsLeaveNoTempFiles) {
+  const auto before = irTempLeaves();
+
+  ChainTestProcessor proc;
+  // A short cab IR and a long stereo reverb IR: the reverb also builds the
+  // true-stereo convolver, the second file-reading path in the loader.
+  restoreMonoChain(proc, {makeIrBlockTree("blk-cab", 1, 100, "cab-ir-test.wav"),
+                          makeIrBlockTree("blk-verb", 2, 101, "reverb-ir-stereo-test.wav")});
+  ASSERT_TRUE(waitForChainLoaded(proc));
+
+  EXPECT_TRUE(noNewIrTempFilesSettle(before));
+}
+
+TEST(IrTempFileTest, FailedIrLoadLeavesNoTempFile) {
+  const auto before = irTempLeaves();
+
+  ChainTestProcessor proc;
+  restoreMonoChain(proc, {makeJunkIrBlockTree("blk-junk", 1, 100)});
+  ASSERT_TRUE(waitForBlockLoadFailed(proc, "blk-junk"));
+
+  EXPECT_TRUE(noNewIrTempFilesSettle(before));
+}
+
+TEST(IrTempFileTest, SweepRemovesOnlyStaleIrTempFiles) {
+  // A private directory stands in for the OS temp dir, so the test owns
+  // every file the sweep sees (the once-per-process startup sweep scans only
+  // the temp root, never this subdirectory).
+  const juce::File dir = osTempDir().getChildFile("t3k-sweep-test-" + juce::Uuid().toString());
+  ASSERT_TRUE(dir.createDirectory());
+
+  const auto makeFileAgedHours = [&dir](const juce::String& name, double hours) {
+    const juce::File f = dir.getChildFile(name);
+    EXPECT_TRUE(f.replaceWithText("x"));
+    if (hours > 0)
+      EXPECT_TRUE(f.setLastModificationTime(juce::Time::getCurrentTime() -
+                                            juce::RelativeTime::hours(hours)));
+    return f;
+  };
+
+  // The two leaked shapes: an old build's uuid-named file and a crashed
+  // build's TemporaryFile, both well past the hour age guard.
+  const juce::File leaked = makeFileAgedHours(juce::Uuid().toString() + "_ir.wav", 2.0);
+  const juce::File crashLeftover = makeFileAgedHours("temp_ab12cd34_ir.wav", 2.0);
+  // A concurrent instance's in-flight file (fresh) and a stale file that
+  // merely lives in the same directory: both must survive.
+  const juce::File inFlight = makeFileAgedHours(juce::Uuid().toString() + "_ir.wav", 0.0);
+  const juce::File foreign = makeFileAgedHours("somebody-elses.wav", 2.0);
+
+  EXPECT_EQ(TONE3000Processor::sweepLeakedIrTempFiles(dir), 2);
+  EXPECT_FALSE(leaked.existsAsFile());
+  EXPECT_FALSE(crashLeftover.existsAsFile());
+  EXPECT_TRUE(inFlight.existsAsFile());
+  EXPECT_TRUE(foreign.existsAsFile());
+
+  EXPECT_TRUE(dir.deleteRecursively());
+}


### PR DESCRIPTION
## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
