### PR TITLE
iOS / iPadOS Standalone target: build enablement

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,3 +564,79 @@ jobs:
           name: TONE3000-v${{ env.T3K_VERSION }}-${{ matrix.os }}-${{ matrix.arch }}
           path: build/TONE3000-v*-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
           if-no-files-found: error
+
+  # iOS Simulator: configure and build the Standalone app for the iPad
+  # Simulator so the iOS target cannot silently rot. No signing, no
+  # installer: the unsigned Simulator .app is uploaded for QA. Xcode is the
+  # generator here (the iOS presets need it for the app bundle and the
+  # multi-config build), and it does not honour the sccache compiler
+  # launchers, so this job builds cold.
+  ios-simulator:
+    name: iOS Simulator
+    runs-on: macos-14
+    environment: builds
+    env:
+      VITE_T3K_PUBLISHABLE_KEY: ${{ secrets.VITE_T3K_PUBLISHABLE_KEY }}
+      VITE_T3K_UPDATE_NOTICE: ${{ vars.VITE_T3K_UPDATE_NOTICE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Read version
+        run: echo "T3K_VERSION=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_ENV"
+
+      - name: Cache CPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            libs/juce
+            libs/googletest
+            libs/clap-juce-extensions
+          key: cpm-deps-ios-${{ hashFiles('CMakeLists.txt', 'plugin/CMakeLists.txt') }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+
+      # Same order as the desktop job: configure first so CPM fetches JUCE,
+      # which the UI build needs, then reconfigure so the content-hashed UI
+      # assets are picked up (plugin/CMakeLists.txt globs them at configure).
+      - name: Configure CMake (iOS Simulator bootstrap)
+        run: cmake --preset ios-simulator
+
+      - name: Build UI
+        run: |
+          cd ui
+          npm ci
+          npm run build
+          cd ..
+
+      - name: Reconfigure CMake (iOS Simulator)
+        run: cmake --preset ios-simulator
+
+      - name: Build Standalone (iOS Simulator)
+        run: |
+          cmake --build build-ios --config ${{ env.BUILD_TYPE }} \
+            --target TONE3000_Standalone --parallel -- -sdk iphonesimulator
+
+      - name: Package Simulator app
+        run: |
+          set -euo pipefail
+          APP="build-ios/plugin/TONE3000_artefacts/${{ env.BUILD_TYPE }}/Standalone/TONE3000.app"
+          test -d "$APP"
+          ditto -c -k --keepParent "$APP" \
+            "build-ios/TONE3000-v${T3K_VERSION}-ios-simulator.zip"
+
+      - name: Upload artifacts (iOS Simulator)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: TONE3000-v${{ env.T3K_VERSION }}-ios-simulator
+          path: build-ios/TONE3000-v*-ios-simulator.zip
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 .vscode/
 libs/
 bin/
-build/
-build-arm64/
-build-x86_64/
+build*/
 release-build/
 vs-build/
 output/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,11 @@
 .vscode/
 libs/
 bin/
-build*/
+build/
+build-arm64/
+build-x86_64/
+build-ios/
+build-ios-device/
 release-build/
 vs-build/
 output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,22 @@ cmake_minimum_required(VERSION 3.22.1)
 # 10.15 covers the Intel slice, the arm64 slice is floored at 11.0 by the
 # toolchain (Apple Silicon minimum). Overridable with
 # -DCMAKE_OSX_DEPLOYMENT_TARGET=... ; harmless on non-Apple platforms.
-if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+# iOS builds share CMAKE_OSX_DEPLOYMENT_TARGET with macOS but need an iOS
+# version number, so the 10.15 floor below would be nonsense there. T3K_IOS is
+# the single switch the rest of the build reads; CMAKE_SYSTEM_NAME is set on
+# the command line (-DCMAKE_SYSTEM_NAME=iOS) so it is already visible here,
+# before project().
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(T3K_IOS TRUE)
+endif()
+
+if(T3K_IOS)
+    # iOS 16 is the floor JUCE 9 / WKWebView / AVAudioSession are exercised
+    # against here, and covers every iPad that can run this at all.
+    if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "16.0" CACHE STRING "Minimum iOS version" FORCE)
+    endif()
+elseif(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
     set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS version" FORCE)
 endif()
 
@@ -899,4 +914,9 @@ CPMAddPackage(
 enable_testing() # Allow running build tests
 
 add_subdirectory(plugin) # Add plugin project
-add_subdirectory(test)   # DSP test suite (DspTests, see script/test-dsp.sh)
+# The DSP suite is a host-run console binary (it reads test assets off the
+# build machine's disk and is driven by script/test-dsp.sh). Cross-compiling it
+# for iOS produces something that cannot be run, so keep it out of that build.
+if (NOT T3K_IOS)
+    add_subdirectory(test)   # DSP test suite (DspTests, see script/test-dsp.sh)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,16 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
 project(TONE3000 VERSION ${T3K_VERSION} LANGUAGES C CXX)
 add_compile_options(-fsigned-char)
 
+# A toolchain file sets CMAKE_SYSTEM_NAME too late for the block above (it is
+# only read at project()), so T3K_IOS would stay off, the 10.15 macOS floor
+# would be forced into the cache and the desktop plugin formats would be
+# built for iOS. Fail here with the fix rather than somewhere in the plugin.
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS" AND NOT T3K_IOS)
+    message(FATAL_ERROR "iOS: pass -DCMAKE_SYSTEM_NAME=iOS on the configure command line "
+        "(or use the ios-simulator / ios-device presets); a toolchain file sets it too late "
+        "for the deployment-target floor.")
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,13 +36,12 @@
     {
       "name": "ios-simulator",
       "displayName": "iOS Standalone (Simulator)",
-      "description": "Standalone-only iOS app for the iPad Simulator. Build with: cmake --build build-ios --target TONE3000_Standalone -- -sdk iphonesimulator",
+      "description": "Standalone-only iOS app for the iPad Simulator. Xcode is multi-config, so pick the configuration at build time; use Release, a Debug build points the WebView at the dev server. Build with: cmake --build build-ios --config Release --target TONE3000_Standalone -- -sdk iphonesimulator",
       "generator": "Xcode",
       "binaryDir": "build-ios",
       "cacheVariables": {
         "CMAKE_SYSTEM_NAME": "iOS",
-        "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
-        "CMAKE_BUILD_TYPE": "Debug"
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,6 +32,28 @@
       "name": "Xcode",
       "generator": "Xcode",
       "binaryDir": "xcode-build"
+    },
+    {
+      "name": "ios-simulator",
+      "displayName": "iOS Standalone (Simulator)",
+      "description": "Standalone-only iOS app for the iPad Simulator. Build with: cmake --build build-ios --target TONE3000_Standalone -- -sdk iphonesimulator",
+      "generator": "Xcode",
+      "binaryDir": "build-ios",
+      "cacheVariables": {
+        "CMAKE_SYSTEM_NAME": "iOS",
+        "CMAKE_OSX_DEPLOYMENT_TARGET": "16.0",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "ios-device",
+      "displayName": "iOS Standalone (device)",
+      "description": "Same as ios-simulator but code signed for a physical iPad. Build with -sdk iphoneos -allowProvisioningUpdates; add -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=<id> if Xcode cannot pick your team.",
+      "inherits": "ios-simulator",
+      "binaryDir": "build-ios-device",
+      "cacheVariables": {
+        "CMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY": "Apple Development"
+      }
     }
   ],
   "buildPresets": [

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -1,0 +1,87 @@
+# iOS (iPad) build
+
+Standalone-only iPad build of the plugin: the same C++ and the same React
+UI, with every platform difference behind `#if JUCE_IOS`. Desktop behaviour
+is unchanged. AUv3 is out of scope; iPhone is untested.
+
+Deployment target iOS 16. Landscape only.
+
+## Build
+
+The UI is embedded as JUCE binary data, so it is built first.
+
+```sh
+cd ui && npm ci && npm run build && cd ..
+
+# Simulator
+cmake --preset ios-simulator
+cmake --build build-ios --config Release --target TONE3000_Standalone -- -sdk iphonesimulator
+
+# Device
+cmake --preset ios-device
+cmake --build build-ios-device --config Release --target TONE3000_Standalone -- \
+  -sdk iphoneos -allowProvisioningUpdates
+```
+
+Build **Release** on the Simulator. A Debug iOS build points the WebView at
+`http://localhost:5173/`, so it shows a dead page and logs "navigation failed".
+
+`-DT3K_IOS_BUNDLE_ID=<id>` signs under your own identity. Changing it on a
+device that already holds the app gives a fresh, empty Documents folder, so
+keep it stable once models are loaded. Add
+`-DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=<id>` if Xcode cannot pick your team.
+
+**Reconfigure after every UI change.** `plugin/CMakeLists.txt` collects the
+webview with `file(GLOB_RECURSE)`, which runs at configure time, and Vite's
+asset filenames are content-hashed. Without a reconfigure the app keeps
+serving the previously embedded bundle and looks like your change did nothing.
+The requested asset name in the app's log tells you which bundle is running.
+
+## Install and log
+
+```sh
+xcrun simctl install <udid> build-ios/plugin/TONE3000_artefacts/Release/Standalone/TONE3000.app
+xcrun simctl launch <udid> <bundle-id>
+
+# The app's own log: console.* from the WebView is forwarded into it, which
+# is the most useful debugging channel on both Simulator and device.
+tail -f "$(xcrun simctl get_app_container <udid> <bundle-id> data)/Library/TONE3000/TONE3000.log"
+```
+
+Simulator screenshots come out portrait while the app renders landscape.
+
+## Platform notes worth knowing
+
+- **Picker results must be read through security-scoped URLs.** A file chosen
+  outside the app container is unreadable through its raw path. A test with
+  the file *inside* the container passes and proves nothing.
+- **The app data container's UUID rotates on every reinstall and every app
+  update.** Any absolute path the plugin persisted then names a directory
+  that no longer exists, and the only path it persists is a local model's
+  stash URL, in the tone JSON that rides presets, the saved app state and
+  undo snapshots. `resolveLocalModelFile` re-roots the stored (content-hashed)
+  file name under the current stash folder; a path that still exists is used
+  as-is, which is every desktop case. Presets and project state were never
+  affected: they embed the model bytes.
+- `xcrun simctl privacy grant microphone` does not suppress the prompt;
+  `AVAudioSession` still asks once.
+- **`UIRequiresFullScreen` no longer opts an app out of multitasking** on
+  iPadOS 26: a second app dragged from the Dock windows itself over this one
+  regardless. The key is therefore not set. The app is not resized by it (the
+  other app floats), so the layout is unaffected.
+- The `NAM` static library must be force-loaded on iOS as well as macOS.
+  `$<PLATFORM_ID:...>` reports `iOS`, not `Darwin`, when cross-compiling, so
+  without both the linker strips the model-architecture registrations and
+  loads fail with "No config parser registered for ...".
+
+## Known gaps
+
+- The UI is the desktop UI. It renders and is usable, but it is not yet
+  adapted for touch: hit targets, gestures and the "On this iPad" local
+  browsing section are a separate change.
+- Load Folder is a multi-select on iOS: a security-scoped *directory* cannot
+  be enumerated, so the picker returns files instead.
+- Dragging a `.nam` from Files onto a tile is untested. The receiving code is
+  the same HTML5 drop path the desktop uses, and the app does window alongside
+  Files, but the drag could not be driven from the automation.
+- AUv3 is not built. Only the Standalone app exists on iOS.

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -43,14 +43,26 @@ The requested asset name in the app's log tells you which bundle is running.
 
 ## Install and log
 
+Each preset writes to its own build directory: `build-ios` for
+`ios-simulator`, `build-ios-device` for `ios-device`. The artefact path under
+each is the same.
+
 ```sh
+# Simulator
 xcrun simctl install <udid> build-ios/plugin/TONE3000_artefacts/Release/Standalone/TONE3000.app
 xcrun simctl launch <udid> <bundle-id>
+
+# Device
+xcrun devicectl device install app --device <udid> \
+  build-ios-device/plugin/TONE3000_artefacts/Release/Standalone/TONE3000.app
 
 # The app's own log: console.* from the WebView is forwarded into it, which
 # is the most useful debugging channel on both Simulator and device.
 tail -f "$(xcrun simctl get_app_container <udid> <bundle-id> data)/Library/TONE3000/TONE3000.log"
 ```
+
+Xcode's Devices and Simulators window installs either build too, if you
+prefer it to the command line.
 
 Simulator screenshots come out portrait while the app renders landscape.
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -23,6 +23,10 @@ cmake --build build-ios-device --config Release --target TONE3000_Standalone -- 
   -sdk iphoneos -allowProvisioningUpdates
 ```
 
+The **Build Plugin** workflow (`.github/workflows/build.yml`) has an
+`iOS Simulator` job that runs the same Simulator build on a macOS runner and
+uploads the unsigned `.app` as an artifact.
+
 Build **Release** on the Simulator. A Debug iOS build points the WebView at
 `http://localhost:5173/`, so it shows a dead page and logs "navigation failed".
 

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -3,7 +3,17 @@ cmake_minimum_required(VERSION 3.22.1)
 # Minimum macOS version; see the comment in the root CMakeLists.txt. Repeated
 # here (before project()) so a standalone configure of this directory gets the
 # same floor instead of the build host's macOS version.
-if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+# See the comment in the root CMakeLists.txt: iOS needs an iOS version here,
+# not the macOS floor. Repeated for a standalone configure of this directory.
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(T3K_IOS TRUE)
+endif()
+
+if(T3K_IOS)
+    if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+        set(CMAKE_OSX_DEPLOYMENT_TARGET "16.0" CACHE STRING "Minimum iOS version" FORCE)
+    endif()
+elseif(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET OR CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
     set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "Minimum macOS version" FORCE)
 endif()
 
@@ -32,13 +42,24 @@ option(BUILD_LV2 "Build LV2 format (native Linux plugin standard)" ON)
 option(BUILD_CLAP "Build CLAP format (via clap-juce-extensions)" ON)
 set(_plugin_formats "VST3") # Default plugin format
 
+# iOS has no desktop plugin host, so none of the plugin formats apply: VST3,
+# AU (the desktop v2 wrapper), AAX, LV2 and CLAP are all macOS/Windows/Linux
+# only. The app that ships on an iPad is the Standalone. AUv3 would be the
+# in-host format there and is deliberately out of scope for this spike.
+if (T3K_IOS)
+    set(_plugin_formats "")
+    set(BUILD_AAX OFF)
+    set(BUILD_LV2 OFF)
+    set(BUILD_CLAP OFF)
+endif()
+
 # Build for Desktop or Embedded
 if (NOT HEADLESS)
     set(JUCE_WEB_BROWSER_VALUE 1)               # Webview UI for Desktop
     set(NEEDS_WEB_BROWSER_VALUE TRUE)           # enable, need browser for webview on linux
     list(APPEND _plugin_formats "Standalone")   # Add Standalone format
     # Enable AU (Apple) format on macOS
-    if (APPLE)
+    if (APPLE AND NOT T3K_IOS)
         list(APPEND _plugin_formats "AU")
     endif()
     if (BUILD_AAX)
@@ -63,7 +84,18 @@ else()
     add_compile_definitions(HEADLESS=1)
 endif()
 
-add_subdirectory(NeuralAmpModelerCore)
+# NeuralAmpModelerCore's own CMakeLists only knows Darwin, Linux and Windows
+# and hard-fails with "Unrecognized Platform!" on anything else, iOS included.
+# Nothing in this build actually needs it: the NAM static library below is
+# compiled here from NAM_SRC precisely to keep the submodule pristine, and the
+# include paths and NAM_ENABLE_A2_FAST definition it would set are directory
+# scoped (they never reached this target anyway; both are set explicitly
+# below). The only things it contributes are the submodule's own dev tools,
+# which are excluded from the default build a few lines down. So skip it on
+# iOS and leave every other platform on the existing path.
+if (NOT T3K_IOS)
+    add_subdirectory(NeuralAmpModelerCore)
+endif()
 
 # The NAM dev tools (benchmarks, render, run_tests) are only used by the
 # submodule's own CI; nothing in the plugin build needs them. They also don't
@@ -107,10 +139,52 @@ target_compile_definitions(NAM PRIVATE NAM_ENABLE_A2_FAST)
 # bakes in Apple's icon grid: a rounded-rect chip with margins on a transparent
 # canvas. Windows wants the full-bleed square. Both derive from the t3k mark;
 # regen notes in design/app-icon-macos.svg.
-if(APPLE)
+# iOS masks the icon itself (the springboard applies the squircle), so it wants
+# the full-bleed square like Windows, not the macOS artwork with baked-in margins.
+if(APPLE AND NOT T3K_IOS)
     set(_app_icon "${CMAKE_CURRENT_SOURCE_DIR}/icon/icon-macos.png")
 else()
     set(_app_icon "${CMAKE_CURRENT_SOURCE_DIR}/icon/icon.png")
+endif()
+
+# Extra juce_add_plugin arguments for the iOS app. Kept in one list so the
+# call below stays a single unchanged block on every other platform.
+#
+# - BUNDLE_ID: T3K_IOS_BUNDLE_ID, defaulting to the project's own id. Pass
+#   -DT3K_IOS_BUNDLE_ID=<your id> to sign under a personal team; changing it
+#   on a device that already holds the app gives a fresh, empty Documents.
+# - BACKGROUND_AUDIO_ENABLED: without the "audio" UIBackgroundModes entry iOS
+#   suspends the audio session the moment the app leaves the foreground, which
+#   also breaks Inter-App Audio style use next to a DAW.
+# - FILE_SHARING_ENABLED / DOCUMENT_BROWSER_ENABLED: the local .nam and IR
+#   story on iOS is the Files app. These two put the app's Documents folder in
+#   Files (UIFileSharingEnabled + LSSupportsOpeningDocumentsInPlace) so a user
+#   can drop captures in, and let juce::FileChooser open them in place.
+# - IPAD_SCREEN_ORIENTATIONS: the faceplate is landscape by design. iPhone is
+#   out of scope for this PR, so no iPhone orientation list.
+# The microphone and Bluetooth permission strings the plugin already declares
+# are the same keys iOS wants, so they are left in the shared block below.
+set(T3K_IOS_BUNDLE_ID "com.TONE3000.TONE3000" CACHE STRING
+    "Bundle identifier for the iOS app (override to sign under a personal team)")
+
+set(_t3k_ios_args "")
+if (T3K_IOS)
+    set(_t3k_ios_args
+        BUNDLE_ID "${T3K_IOS_BUNDLE_ID}"
+        BACKGROUND_AUDIO_ENABLED TRUE
+        FILE_SHARING_ENABLED TRUE
+        DOCUMENT_BROWSER_ENABLED TRUE
+        IPAD_SCREEN_ORIENTATIONS UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
+    )
+endif()
+
+# LSMinimumSystemVersion is a macOS Launch Services key; on iOS the deployment
+# target already rides in the binary and MinimumOSVersion, so merging a macOS
+# key there would just be noise in the plist.
+if (T3K_IOS)
+    set(_t3k_plist_to_merge "")
+else()
+    set(_t3k_plist_to_merge PLIST_TO_MERGE "<plist version=\"1.0\"><dict><key>LSMinimumSystemVersion</key><string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string></dict></plist>")
 endif()
 
 juce_add_plugin(${PROJECT_NAME}
@@ -146,7 +220,8 @@ juce_add_plugin(${PROJECT_NAME}
     # Finder's Get Info read LSMinimumSystemVersion, and without it the app
     # looks installable on any macOS. One value for the universal binary: the
     # Intel floor, since every arm64 Mac runs 11.0 or later anyway.
-    PLIST_TO_MERGE "<plist version=\"1.0\"><dict><key>LSMinimumSystemVersion</key><string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string></dict></plist>"
+    ${_t3k_plist_to_merge}
+    ${_t3k_ios_args}
     ICON_BIG "${_app_icon}"
 )
 
@@ -248,7 +323,10 @@ target_link_libraries(${PROJECT_NAME}
         juce::juce_gui_extra
         # NAM: force_load/whole-archive so static factory::Helper initializers
         # (ConvNet, LSTM, WaveNet) are not stripped by the linker
-        $<$<PLATFORM_ID:Darwin>:-Wl,-force_load,$<TARGET_FILE:NAM>>
+        # PLATFORM_ID is "iOS" (not "Darwin") when cross-compiling for iOS, so
+        # both have to be listed or the iOS link drops every model architecture
+        # and NAM loads fail with "No config parser registered for ...".
+        $<$<PLATFORM_ID:Darwin,iOS>:-Wl,-force_load,$<TARGET_FILE:NAM>>
         # Linux: flags and library must be separate link items. A single
         # "-Wl,--whole-archive,NAM,-Wl,..." item gets comma-split by the GCC
         # driver, passing a literal "-Wl" to ld ("unrecognized option '-Wl'").
@@ -335,12 +413,18 @@ if (UNIX AND NOT APPLE)
     target_compile_definitions(${PROJECT_NAME} PUBLIC JUCE_USE_XINPUT=0)
 endif()
 
-# Use native macOS title bar for standalone app
-if (APPLE AND NOT HEADLESS)
+# Use native macOS title bar for standalone app. On iOS there is no title bar
+# and no resizable window: kiosk mode is exactly what a full-screen iPad app
+# wants, so leave JUCE's default (on) alone there.
+if (APPLE AND NOT HEADLESS AND NOT T3K_IOS)
     target_compile_definitions(${PROJECT_NAME}
         PUBLIC JUCE_STANDALONE_FILTER_WINDOW_USE_KIOSK_MODE=0
     )
-    # AVFoundation: query/request the OS microphone permission (AudioPermissions.mm).
+endif()
+
+if (APPLE AND NOT HEADLESS)
+    # AVFoundation: query/request the OS microphone permission
+    # (AudioPermissions.mm; AVCaptureDevice on macOS, AVAudioSession on iOS).
     find_library(AVFOUNDATION_FRAMEWORK AVFoundation)
     target_link_libraries(${PROJECT_NAME} PRIVATE ${AVFOUNDATION_FRAMEWORK})
 endif()

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -164,11 +164,10 @@ endif()
 #   out of scope for this PR, so no iPhone orientation list.
 # The microphone and Bluetooth permission strings the plugin already declares
 # are the same keys iOS wants, so they are left in the shared block below.
-set(T3K_IOS_BUNDLE_ID "com.TONE3000.TONE3000" CACHE STRING
-    "Bundle identifier for the iOS app (override to sign under a personal team)")
-
 set(_t3k_ios_args "")
 if (T3K_IOS)
+    set(T3K_IOS_BUNDLE_ID "com.TONE3000.TONE3000" CACHE STRING
+        "Bundle identifier for the iOS app (override to sign under a personal team)")
     set(_t3k_ios_args
         BUNDLE_ID "${T3K_IOS_BUNDLE_ID}"
         BACKGROUND_AUDIO_ENABLED TRUE

--- a/plugin/docs/local-models.md
+++ b/plugin/docs/local-models.md
@@ -73,6 +73,12 @@ Its lifecycle is self-maintaining:
   stash files unused for a week. Clearing on startup would be wrong:
   instances in other processes may still hold undo history that references
   the files by path.
+- **The name is the address.** A block's `model_url` persists the stash
+  path absolutely, in presets, DAW/app state and undo snapshots. Reads go
+  back through `resolveLocalModelFile`, which falls back to the same file
+  name under the *current* stash root when the stored path is gone. That is
+  a no-op on desktop (the root never moves) and is what keeps iOS working:
+  the app data container's UUID rotates on every reinstall or app update.
 - **Self-healing.** Presets and DAW state embed the model bytes
   (`ModelCache`), so they reopen without the stash, on any machine. When
   such a load hits the embedded cache and the stash copy is missing (GC'd,

--- a/plugin/docs/local-models.md
+++ b/plugin/docs/local-models.md
@@ -76,8 +76,11 @@ Its lifecycle is self-maintaining:
 - **The name is the address.** A block's `model_url` persists the stash
   path absolutely, in presets, DAW/app state and undo snapshots. Reads go
   back through `resolveLocalModelFile`, which falls back to the same file
-  name under the *current* stash root when the stored path is gone. That is
-  a no-op on desktop (the root never moves) and is what keeps iOS working:
+  name under the *current* stash root when the stored path is gone. A path
+  this machine wrote always still exists, so desktop loads are untouched; the
+  one desktop case it changes is a preset or state carrying a stash URL from
+  another machine, which now re-stashes locally from the embedded bytes
+  instead of reading the embedded cache alone. It is what keeps iOS working:
   the app data container's UUID rotates on every reinstall or app update.
 - **Self-healing.** Presets and DAW state embed the model bytes
   (`ModelCache`), so they reopen without the stash, on any machine. When

--- a/plugin/include/AudioPermissions.h
+++ b/plugin/include/AudioPermissions.h
@@ -14,8 +14,8 @@
  * audio API explains why. This surfaces that state to the settings UI (banner
  * + inline alert) and offers a one-click jump to the OS privacy page.
  *
- * Platform-specific implementations: AudioPermissions.mm (macOS, AVFoundation)
- * and AudioPermissions.cpp (Windows/Linux fallback).
+ * Platform-specific implementations: AudioPermissions.mm (macOS, AVFoundation;
+ * iOS, AVAudioSession) and AudioPermissions.cpp (Windows/Linux fallback).
  */
 namespace AudioPermissions {
 
@@ -36,7 +36,8 @@ MicStatus getMicStatus();
 void requestMicAccess(std::function<void(bool)> onComplete);
 
 /** Open the OS page where the user grants mic access to this app (macOS:
-    Privacy & Security > Microphone). No-op where unsupported. */
+    Privacy & Security > Microphone; iOS: the app's own page in Settings).
+    No-op where unsupported. */
 void openMicSettings();
 
 }  // namespace AudioPermissions

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -103,6 +103,19 @@ public:
   // folder name. A single file must be .nam or .wav; title is the file
   // name. Same return contract as loadLocalTone.
   juce::var loadLocalTonePath(const juce::File& source, const std::string& targetInsertId = {});
+
+#if JUCE_IOS
+  /** URL sibling of loadLocalTonePath, for the iOS document picker.
+      Files chosen from the Files app live outside the app sandbox and are
+      readable only through the security scope JUCE's FileChooser bookmarked,
+      so the bytes have to come through juce::URL rather than the raw path.
+      Takes 1..N URLs because multi-select stands in for the folder route on
+      iOS (a security-scoped directory cannot be enumerated through
+      juce::URL); see pickLocalToneFile. Same return contract as
+      loadLocalTone. */
+  juce::var loadLocalToneUrls(const juce::Array<juce::URL>& sources,
+                              const std::string& targetInsertId = {});
+#endif
   // Age out local-model stash files unused for a week (runs once per
   // process, off-thread). Called from the constructor.
   static void cleanLocalModelStash();

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -140,6 +140,13 @@ public:
   // desktop case (the root never moves there). Empty File for a non-file URL.
   static juce::File resolveLocalModelFile(const juce::File& stashRoot,
                                           const juce::String& modelUrl);
+  // The file name a URL names, percent-decoded. juce::URL::getFileName returns
+  // the raw, still-escaped last path component, so a file picked as
+  // "Deluxe Reverb 2.nam" reads back as "Deluxe%20Reverb%202.nam" and would
+  // reach the title, the model name and the stash name in that form. Desktop
+  // derives names from juce::File and never sees escapes; this keeps the URL
+  // path identical.
+  static juce::String localFileNameFromUrl(const juce::URL& url);
   // Replace the tone of an existing block in place. Keeps the block's chain
   // position and user params (enabled/gains/mix); the new tone's first model
   // is queued for background loading.

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -104,7 +104,6 @@ public:
   // name. Same return contract as loadLocalTone.
   juce::var loadLocalTonePath(const juce::File& source, const std::string& targetInsertId = {});
 
-#if JUCE_IOS
   /** URL sibling of loadLocalTonePath, for the iOS document picker.
       Files chosen from the Files app live outside the app sandbox and are
       readable only through the security scope JUCE's FileChooser bookmarked,
@@ -112,10 +111,10 @@ public:
       Takes 1..N URLs because multi-select stands in for the folder route on
       iOS (a security-scoped directory cannot be enumerated through
       juce::URL); see pickLocalToneFile. Same return contract as
-      loadLocalTone. */
+      loadLocalTone. Compiled on every platform so the DSP suite can test it;
+      only the iOS editor calls it. */
   juce::var loadLocalToneUrls(const juce::Array<juce::URL>& sources,
                               const std::string& targetInsertId = {});
-#endif
   // Age out local-model stash files unused for a week (runs once per
   // process, off-thread). Called from the constructor.
   static void cleanLocalModelStash();

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -128,6 +128,18 @@ public:
   // over an hour (the age guard protects a concurrent instance's in-flight
   // file). Returns how many files it deleted.
   static int sweepLeakedIrTempFiles(const juce::File& tempDir);
+  // Resolve a persisted local-model `file://` URL to the stash file that
+  // actually holds those bytes, given the current stash root. The URL stored
+  // in a block's tone JSON is absolute, and that JSON is persisted in
+  // presets, DAW/app state and undo snapshots; on iOS the app data
+  // container's UUID rotates on every reinstall or app update, so every one
+  // of those paths goes stale. Stash names are content hashes in a flat
+  // folder, so the file name *is* the stable token: when the stored path no
+  // longer exists, the same name under the current root is the same bytes.
+  // A stored path that does exist is returned untouched, which is every
+  // desktop case (the root never moves there). Empty File for a non-file URL.
+  static juce::File resolveLocalModelFile(const juce::File& stashRoot,
+                                          const juce::String& modelUrl);
   // Replace the tone of an existing block in place. Keeps the block's chain
   // position and user params (enabled/gains/mix); the new tone's first model
   // is queued for background loading.

--- a/plugin/src/AudioPermissions.mm
+++ b/plugin/src/AudioPermissions.mm
@@ -3,6 +3,64 @@
 #include <juce_events/juce_events.h>  // MessageManager::callAsync
 
 #import <AVFoundation/AVFoundation.h>
+
+#if JUCE_IOS
+
+#import <UIKit/UIKit.h>
+
+namespace AudioPermissions {
+
+// iOS gates audio input the same way macOS does, but through AVAudioSession
+// rather than AVCaptureDevice: recordPermission is the session-level answer and
+// is what actually decides whether the input bus carries signal. The three
+// states map one for one onto MicStatus, so the rest of the plugin (the
+// settings banner, the inline alert, the one-click jump to privacy settings)
+// works unchanged.
+//
+// ponytail: AVAudioSession.recordPermission is deprecated since iOS 17 in
+// favour of AVAudioApplication, but still works and keeps one code path at a
+// deployment target of iOS 16. Split it under `if (@available(iOS 17.0, *))`
+// when the deprecation becomes a removal.
+
+MicStatus getMicStatus() {
+  const auto fromRecordPermission = [](AVAudioSessionRecordPermission p) {
+    switch (p) {
+      case AVAudioSessionRecordPermissionGranted:
+        return MicStatus::granted;
+      case AVAudioSessionRecordPermissionDenied:
+        return MicStatus::denied;
+      case AVAudioSessionRecordPermissionUndetermined:
+        return MicStatus::unknown;
+    }
+    return MicStatus::unknown;
+  };
+
+  return fromRecordPermission([[AVAudioSession sharedInstance] recordPermission]);
+}
+
+void requestMicAccess(std::function<void(bool)> onComplete) {
+  [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+    // Same contract as the macOS path: the AV callback lands on an arbitrary
+    // queue, so bounce to the message thread before touching JUCE objects.
+    juce::MessageManager::callAsync([onComplete, granted] {
+      if (onComplete)
+        onComplete(static_cast<bool>(granted));
+    });
+  }];
+}
+
+void openMicSettings() {
+  // iOS has no per-pane privacy URL; UIApplicationOpenSettingsURLString opens
+  // this app's own Settings page, where the Microphone switch lives.
+  NSURL* url = [NSURL URLWithString:UIApplicationOpenSettingsURLString];
+  if (url != nil)
+    [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
+}
+
+}  // namespace AudioPermissions
+
+#else
+
 #import <AppKit/AppKit.h>
 
 namespace AudioPermissions {
@@ -40,3 +98,5 @@ void openMicSettings() {
 }
 
 }  // namespace AudioPermissions
+
+#endif  // JUCE_IOS

--- a/plugin/src/Editor.cpp
+++ b/plugin/src/Editor.cpp
@@ -285,6 +285,20 @@ void TONE3000Editor::pickLocalToneFile(
     return;
   }
 
+#if JUCE_IOS
+  // iOS has no usable folder route. The document picker can return a folder
+  // URL, but everything it returns from the Files app is security scoped and a
+  // scoped directory cannot be enumerated through juce::URL, so a picked
+  // folder would be an unreadable handle. Multi-select is the equivalent the
+  // platform does support, so "Load Folder" asks for the files themselves and
+  // the same many-models-at-once path runs on the result.
+  localFileChooser = std::make_unique<juce::FileChooser>(
+      pickFolder ? "Load Files" : "Load File", juce::File{}, juce::String("*.nam;*.wav"));
+
+  const int flags = juce::FileBrowserComponent::openMode |
+                    juce::FileBrowserComponent::canSelectFiles |
+                    (pickFolder ? juce::FileBrowserComponent::canSelectMultipleItems : 0);
+#else
   localFileChooser = std::make_unique<juce::FileChooser>(
       pickFolder ? "Load Folder" : "Load File", juce::File{},
       pickFolder ? juce::String("*") : juce::String("*.nam;*.wav"));
@@ -292,6 +306,7 @@ void TONE3000Editor::pickLocalToneFile(
   const int flags = juce::FileBrowserComponent::openMode |
                     (pickFolder ? juce::FileBrowserComponent::canSelectDirectories
                                 : juce::FileBrowserComponent::canSelectFiles);
+#endif
 
   // The dialog can outlive user patience but not the editor: destroying the
   // editor destroys the chooser (dialog dismissed, callback never fires, and
@@ -309,12 +324,28 @@ void TONE3000Editor::pickLocalToneFile(
             self->localFileChooser.reset();
         });
 
+#if JUCE_IOS
+        // getURLResults(), not getResults(): JUCE's own FileChooser docs say
+        // to use the URL form on mobile, and here it is load bearing rather
+        // than stylistic. The picker's files live outside the app sandbox and
+        // are only readable through the security scope JUCE bookmarked;
+        // getResults() flattens them to raw paths that the sandbox then
+        // refuses to open ("Couldn't read the file"), which is exactly what a
+        // file picked from Files on a device did before this.
+        const auto results = chooser.getURLResults();
+        if (results.isEmpty()) {
+          completion(cancelled());
+          return;
+        }
+        completion(self->processor.loadLocalToneUrls(results, target));
+#else
         const auto results = chooser.getResults();
         if (results.isEmpty()) {
           completion(cancelled());
           return;
         }
         completion(self->processor.loadLocalTonePath(results.getReference(0), target));
+#endif
       });
 }
 

--- a/plugin/src/Editor.cpp
+++ b/plugin/src/Editor.cpp
@@ -2,6 +2,10 @@
 #include "Processor.h"
 
 void TONE3000Editor::parentHierarchyChanged() {
+  // iOS runs the standalone window in kiosk mode: it is already exactly the
+  // screen, has no title bar to flip on and cannot be resized, so the whole
+  // size-preserving dance below has nothing to correct.
+#if ! JUCE_IOS
   if (auto* window = dynamic_cast<juce::DocumentWindow*>(getTopLevelComponent())) {
     // Snapshot our own size before flipping the title bar style: JUCE
     // immediately relayouts the title-bar/content split within the window's
@@ -45,6 +49,7 @@ void TONE3000Editor::parentHierarchyChanged() {
       peer->setCurrentRenderingEngine(0);
 #endif
   }
+#endif  // ! JUCE_IOS
 
 #if JUCE_MAC
   // DAW hosts own the plugin's NSWindow and usually leave mouse-moved events
@@ -116,6 +121,25 @@ TONE3000Editor::TONE3000Editor(TONE3000Processor& p) : AudioProcessorEditor(&p),
   // Grow-only resizing: corner/edge drags scale the whole window between the
   // 1024x578 design size and kMaxScale times it, aspect-locked. Restore the
   // session's scale (persisted via the processor; see ProcessorState.cpp).
+#if JUCE_IOS
+  // iOS gets one fixed, full-screen window: no corner drags, no host resize
+  // request, no persisted scale. Installing the aspect-locked constrainer here
+  // is not merely useless, it is harmful: the kiosk-mode window applies it to
+  // the screen bounds, and on a 4:3 iPad the 1024:578 lock resolves by height,
+  // making the editor ~1814pt wide inside a 1366pt screen and clipping a third
+  // of the UI off the right edge. Take the size the window gives us instead and
+  // let the web UI letterbox its 1024x578 design box into it (useUiScale),
+  // which is the same path a host that refuses a resize already exercises.
+  //
+  // Still start at the design size and with the persisted chrome height, as
+  // every other platform does: an editor that is 0x0 until the kiosk window
+  // hands it bounds makes the UI's first scale calculation divide by a zero
+  // viewport, and totalHeight() is read before the web UI reports its own
+  // extra height back.
+  extraContentHeight = juce::jlimit(0, 160, processor.editorExtraHeight.load());
+  setSize(kWidth, totalHeight());
+  setResizable(false, false);
+#else
   setResizable(true, true);
   // Read the persisted scale before touching the constraints: installing the
   // resize limits already snaps the editor to the 1x minimum, and resized()
@@ -130,6 +154,7 @@ TONE3000Editor::TONE3000Editor(TONE3000Processor& p) : AudioProcessorEditor(&p),
   extraContentHeight = juce::jlimit(0, 160, processor.editorExtraHeight.load());
   updateResizeConstraints();
   applyScaledSize(savedScale);
+#endif  // JUCE_IOS
 }
 
 void TONE3000Editor::applyScaledSize(double scale) {
@@ -152,6 +177,14 @@ void TONE3000Editor::setExtraContentHeight(int pixels, int persistentPixels) {
   // The UI reports design-space pixels; the window change is scaled.
   // Generous ceiling: banner (~44) + hint bar (~36) with headroom to spare.
   const int clamped = juce::jlimit(0, 160, pixels);
+#if JUCE_IOS
+  // The iOS window is the screen; it cannot grow to make room for a chrome
+  // strip. Record the persistent portion for symmetry and let the web UI
+  // shrink the design box to fit, exactly as it does for a host that refuses
+  // the resize.
+  processor.editorExtraHeight.store(juce::jlimit(0, 160, persistentPixels));
+  extraContentHeight = clamped;
+#else
   // Remember the session-persistent portion (the hint bar; the banner is
   // dynamic) even when the window size itself doesn't change, so the next
   // editor opens pre-sized for the chrome the UI will render on first paint.
@@ -173,6 +206,7 @@ void TONE3000Editor::setExtraContentHeight(int pixels, int persistentPixels) {
     c->setFixedAspectRatio(static_cast<double>(kWidth) / totalHeight());
   }
   applyScaledSize(scale);
+#endif  // JUCE_IOS
 }
 
 void TONE3000Editor::timerCallback() {
@@ -292,8 +326,13 @@ void TONE3000Editor::resized() {
     mainWebView->setBounds(getLocalBounds());
   // Skip persisting while we're correcting our own size rather than
   // reflecting one the user (or host) actually chose; see restoringSize.
+  // No user- or host-chosen scale exists on iOS (the window is the screen),
+  // so there is nothing to persist and currentScale() would just record the
+  // screen aspect.
+#if ! JUCE_IOS
   if (!restoringSize)
     processor.editorScale.store(currentScale());
+#endif
 }
 
 // Get the WebView UI resources from BinaryData

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -259,7 +259,7 @@ juce::var stashLocalFileFromDisk(const juce::File& file, juce::String& error) {
 // "Couldn't read the file". juce::URL::createInputStream goes through the
 // bookmark and the scope, so it reads the same bytes the user actually picked.
 juce::var stashLocalFileFromUrl(const juce::URL& url, juce::String& error) {
-  const juce::String filename = url.getFileName();
+  const juce::String filename = TONE3000Processor::localFileNameFromUrl(url);
   juce::MemoryOutputStream bytes;
   const auto in = url.createInputStream(
       juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress));
@@ -439,10 +439,10 @@ juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sou
   // enumerated through juce::URL (there is no listing API behind the
   // bookmark), so "Load Folder" asks for the files themselves instead. See
   // pickLocalToneFile.
-  const juce::String title = sources.size() == 1
-                                 ? sources.getReference(0).getFileName().upToLastOccurrenceOf(
-                                       ".", false, false)
-                                 : juce::String(sources.size()) + " files";
+  const juce::String title =
+      sources.size() == 1
+          ? localFileNameFromUrl(sources.getReference(0)).upToLastOccurrenceOf(".", false, false)
+          : juce::String(sources.size()) + " files";
 
   if (sources.isEmpty())
     return localToneError(title, "Nothing to load");
@@ -454,13 +454,13 @@ juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sou
   // is stable regardless of the order the picker reports.
   juce::Array<juce::URL> picked(sources);
   std::sort(picked.begin(), picked.end(), [](const juce::URL& a, const juce::URL& b) {
-    return a.getFileName().compareNatural(b.getFileName()) < 0;
+    return localFileNameFromUrl(a).compareNatural(localFileNameFromUrl(b)) < 0;
   });
 
   juce::Array<juce::var> models;
   juce::String firstError;
   for (const auto& url : picked) {
-    const juce::String filename = url.getFileName();
+    const juce::String filename = localFileNameFromUrl(url);
     const juce::String extension = filename.fromLastOccurrenceOf(".", true, false).toLowerCase();
     if (extension != ".nam" && extension != ".wav") {
       if (firstError.isEmpty())
@@ -589,6 +589,14 @@ int TONE3000Processor::sweepLeakedIrTempFiles(const juce::File& tempDir) {
     if (file.getLastModificationTime() < cutoff && file.deleteFile())
       ++removed;
   return removed;
+}
+
+juce::String TONE3000Processor::localFileNameFromUrl(const juce::URL& url) {
+  // A file:// URL knows its own local file, which carries the decoded name;
+  // anything else only has the escaped path component to unescape.
+  if (url.isLocalFile())
+    return url.getLocalFile().getFileName();
+  return juce::URL::removeEscapeChars(url.getFileName());
 }
 
 juce::File TONE3000Processor::resolveLocalModelFile(const juce::File& stashRoot,

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -102,7 +102,8 @@ bool namConfigIsA2(const nlohmann::json& modelJson) {
 // remove, undo across a tone swap) re-reads this copy even after the user's
 // original file moved. Content-addressed names dedupe re-drops of the same
 // file; stale entries age out (see cleanLocalModelStash). Same app-data
-// root as PresetManager.
+// root as PresetManager. Persisted URLs are resolved back to this folder by
+// resolveLocalModelFile, which is what survives the iOS container rotating.
 juce::File localModelsDir() {
   juce::File base = juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory);
 #if JUCE_MAC
@@ -590,13 +591,34 @@ int TONE3000Processor::sweepLeakedIrTempFiles(const juce::File& tempDir) {
   return removed;
 }
 
-void TONE3000Processor::refreshLocalStashCopy(const juce::String& modelUrl,
-                                              const std::vector<uint8_t>& bytes) {
+juce::File TONE3000Processor::resolveLocalModelFile(const juce::File& stashRoot,
+                                                    const juce::String& modelUrl) {
   const juce::URL url(modelUrl);
   if (!url.isLocalFile())
-    return;
-  const juce::File stash = url.getLocalFile();
-  if (!stash.isAChildOf(localModelsDir()))
+    return {};
+
+  const juce::File stored = url.getLocalFile();
+  if (stored.existsAsFile())
+    return stored;
+
+  // The stored path is gone. On iOS that is the normal case after a
+  // reinstall or an app update: the data container's UUID rotates, so every
+  // absolute path a preset, an undo snapshot or the saved app state baked in
+  // points at a container that no longer exists, and the block came back as
+  // "Download failed / Retry". Stash names are content hashes in one flat
+  // folder, so re-rooting the name is exact, not a guess. On desktop the
+  // root never moves, so this yields the path we just probed and the outcome
+  // is unchanged; that is why it is not gated on JUCE_IOS.
+  const juce::String name = stored.getFileName();
+  if (name.isEmpty() || name == "." || name == "..")
+    return stored;
+  return stashRoot.getChildFile(name);
+}
+
+void TONE3000Processor::refreshLocalStashCopy(const juce::String& modelUrl,
+                                              const std::vector<uint8_t>& bytes) {
+  const juce::File stash = resolveLocalModelFile(localModelsDir(), modelUrl);
+  if (stash == juce::File() || !stash.isAChildOf(localModelsDir()))
     return;
 
   if (stash.existsAsFile()) {
@@ -619,15 +641,18 @@ std::vector<uint8_t> TONE3000Processor::fetchModelFromUrl(const juce::String& mo
   // Local-file models (drag-and-drop loads) resolve to their stash copy:
   // no network, no auth. See loadLocalTone.
   if (url.isLocalFile()) {
+    // Through resolveLocalModelFile, not url.getLocalFile(): a path persisted
+    // before an iOS reinstall names a container that is gone.
+    const juce::File stash = resolveLocalModelFile(localModelsDir(), modelUrl);
     juce::MemoryBlock data;
-    if (!url.getLocalFile().loadFileAsData(data) || data.getSize() == 0) {
+    if (!stash.loadFileAsData(data) || data.getSize() == 0) {
       juce::Logger::writeToLog("[ModelLoader] Local model file missing or unreadable: " +
                                modelUrl);
       return {};
     }
     // In use, so keep the GC away (mtime is its liveness signal, see
     // cleanLocalModelStash).
-    url.getLocalFile().setLastModificationTime(juce::Time::getCurrentTime());
+    stash.setLastModificationTime(juce::Time::getCurrentTime());
     const auto* bytes = static_cast<const uint8_t*>(data.getData());
     return std::vector<uint8_t>(bytes, bytes + data.getSize());
   }

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -246,6 +246,31 @@ juce::var stashLocalFileFromDisk(const juce::File& file, juce::String& error) {
   return stashLocalBytes(file.getFileName(), bytes, error);
 }
 
+#if JUCE_IOS
+// A file the OS document picker handed us as a security-scoped URL.
+//
+// iOS is the reason this exists. Everything the picker returns from the Files
+// app lives outside the app sandbox (an iCloud / file-provider container), and
+// the app is only allowed to touch it through the security scope JUCE's
+// FileChooser opened and stored as a bookmark. Reading the raw path with a
+// FileInputStream, which is what stashLocalFileFromDisk does and what every
+// desktop build correctly does, is refused by the sandbox and surfaces as
+// "Couldn't read the file". juce::URL::createInputStream goes through the
+// bookmark and the scope, so it reads the same bytes the user actually picked.
+juce::var stashLocalFileFromUrl(const juce::URL& url, juce::String& error) {
+  const juce::String filename = url.getFileName();
+  juce::MemoryOutputStream bytes;
+  const auto in = url.createInputStream(
+      juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress));
+  if (in == nullptr || bytes.writeFromInputStream(*in, -1) <= 0) {
+    juce::Logger::writeToLog("[LocalLoad] " + filename + ": Couldn't read the file");
+    error = "Couldn't read the file";
+    return {};
+  }
+  return stashLocalBytes(filename, bytes, error);
+}
+#endif  // JUCE_IOS
+
 // Shared user-facing error result for the local-load entry points.
 juce::var localToneError(const juce::String& title, const juce::String& message) {
   juce::Logger::writeToLog("[LocalLoad] " + title + ": " + message);
@@ -404,6 +429,59 @@ juce::var TONE3000Processor::loadLocalTonePath(const juce::File& source,
 
   return finishLocalToneLoad(title, {model}, {}, 1, targetInsertId);
 }
+
+#if JUCE_IOS
+juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sources,
+                                               const std::string& targetInsertId) {
+  // Multi-select stands in for the folder route on iOS: the document picker
+  // can hand back a folder URL, but a security-scoped directory cannot be
+  // enumerated through juce::URL (there is no listing API behind the
+  // bookmark), so "Load Folder" asks for the files themselves instead. See
+  // pickLocalToneFile.
+  const juce::String title = sources.size() == 1
+                                 ? sources.getReference(0).getFileName().upToLastOccurrenceOf(
+                                       ".", false, false)
+                                 : juce::String(sources.size()) + " files";
+
+  if (sources.isEmpty())
+    return localToneError(title, "Nothing to load");
+  if (sources.size() > kMaxFolderModels)
+    return localToneError(
+        title, "Too many files (max " + juce::String(kMaxFolderModels) + ")");
+
+  // Natural name order, matching the folder and drop paths, so the model list
+  // is stable regardless of the order the picker reports.
+  juce::Array<juce::URL> picked(sources);
+  std::sort(picked.begin(), picked.end(), [](const juce::URL& a, const juce::URL& b) {
+    return a.getFileName().compareNatural(b.getFileName()) < 0;
+  });
+
+  juce::Array<juce::var> models;
+  juce::String firstError;
+  for (const auto& url : picked) {
+    const juce::String filename = url.getFileName();
+    const juce::String extension = filename.fromLastOccurrenceOf(".", true, false).toLowerCase();
+    if (extension != ".nam" && extension != ".wav") {
+      if (firstError.isEmpty())
+        firstError = "Only .nam and .wav files are supported";
+      continue;
+    }
+    juce::String error;
+    const juce::var model = stashLocalFileFromUrl(url, error);
+    if (!model.isObject()) {
+      if (firstError.isEmpty())
+        firstError = error;
+      continue;
+    }
+    models.add(model);
+  }
+
+  if (models.isEmpty())
+    return localToneError(title, firstError.isEmpty() ? "Couldn't read the file" : firstError);
+
+  return finishLocalToneLoad(title, models, firstError, picked.size(), targetInsertId);
+}
+#endif  // JUCE_IOS
 
 juce::var TONE3000Processor::finishLocalToneLoad(const juce::String& title,
                                                  const juce::Array<juce::var>& stashedModels,

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -247,11 +247,13 @@ juce::var stashLocalFileFromDisk(const juce::File& file, juce::String& error) {
   return stashLocalBytes(file.getFileName(), bytes, error);
 }
 
-#if JUCE_IOS
 // A file the OS document picker handed us as a security-scoped URL.
 //
-// iOS is the reason this exists. Everything the picker returns from the Files
-// app lives outside the app sandbox (an iCloud / file-provider container), and
+// iOS is the reason this exists, and iOS is the only caller (see
+// pickLocalToneFile); it is compiled everywhere so the DSP suite, which does
+// not build for iOS, can exercise the same code the iPad runs. Everything the
+// picker returns from the Files app lives outside the app sandbox (an iCloud /
+// file-provider container), and
 // the app is only allowed to touch it through the security scope JUCE's
 // FileChooser opened and stored as a bookmark. Reading the raw path with a
 // FileInputStream, which is what stashLocalFileFromDisk does and what every
@@ -270,7 +272,6 @@ juce::var stashLocalFileFromUrl(const juce::URL& url, juce::String& error) {
   }
   return stashLocalBytes(filename, bytes, error);
 }
-#endif  // JUCE_IOS
 
 // Shared user-facing error result for the local-load entry points.
 juce::var localToneError(const juce::String& title, const juce::String& message) {
@@ -431,21 +432,22 @@ juce::var TONE3000Processor::loadLocalTonePath(const juce::File& source,
   return finishLocalToneLoad(title, {model}, {}, 1, targetInsertId);
 }
 
-#if JUCE_IOS
 juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sources,
                                                const std::string& targetInsertId) {
   // Multi-select stands in for the folder route on iOS: the document picker
   // can hand back a folder URL, but a security-scoped directory cannot be
   // enumerated through juce::URL (there is no listing API behind the
   // bookmark), so "Load Folder" asks for the files themselves instead. See
-  // pickLocalToneFile.
+  // pickLocalToneFile. Not gated on JUCE_IOS so the DSP suite can run it;
+  // the editor only reaches it on iOS.
+  if (sources.isEmpty())
+    return localToneError("Load Files", "Nothing to load");
+
   const juce::String title =
       sources.size() == 1
           ? localFileNameFromUrl(sources.getReference(0)).upToLastOccurrenceOf(".", false, false)
           : juce::String(sources.size()) + " files";
 
-  if (sources.isEmpty())
-    return localToneError(title, "Nothing to load");
   if (sources.size() > kMaxFolderModels)
     return localToneError(
         title, "Too many files (max " + juce::String(kMaxFolderModels) + ")");
@@ -459,14 +461,9 @@ juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sou
 
   juce::Array<juce::var> models;
   juce::String firstError;
+  // No extension check here: stashLocalBytes rejects anything but .nam and
+  // .wav by name before it looks at the bytes, with the same message.
   for (const auto& url : picked) {
-    const juce::String filename = localFileNameFromUrl(url);
-    const juce::String extension = filename.fromLastOccurrenceOf(".", true, false).toLowerCase();
-    if (extension != ".nam" && extension != ".wav") {
-      if (firstError.isEmpty())
-        firstError = "Only .nam and .wav files are supported";
-      continue;
-    }
     juce::String error;
     const juce::var model = stashLocalFileFromUrl(url, error);
     if (!model.isObject()) {
@@ -482,7 +479,6 @@ juce::var TONE3000Processor::loadLocalToneUrls(const juce::Array<juce::URL>& sou
 
   return finishLocalToneLoad(title, models, firstError, picked.size(), targetInsertId);
 }
-#endif  // JUCE_IOS
 
 juce::var TONE3000Processor::finishLocalToneLoad(const juce::String& title,
                                                  const juce::Array<juce::var>& stashedModels,
@@ -615,8 +611,14 @@ juce::File TONE3000Processor::resolveLocalModelFile(const juce::File& stashRoot,
   // points at a container that no longer exists, and the block came back as
   // "Download failed / Retry". Stash names are content hashes in one flat
   // folder, so re-rooting the name is exact, not a guess. On desktop the
-  // root never moves, so this yields the path we just probed and the outcome
-  // is unchanged; that is why it is not gated on JUCE_IOS.
+  // root never moves, so a path this machine wrote still exists and comes
+  // back untouched above. The one desktop case this does change is a preset
+  // or saved state carrying a stash URL from another machine or account:
+  // that path is gone here too, and the block now re-roots it into the local
+  // stash (and refreshLocalStashCopy writes the embedded bytes there) instead
+  // of reading from the embedded cache alone. Same bytes, one more file on
+  // disk. Not gated on JUCE_IOS because that case is a repair, not a
+  // regression.
   const juce::String name = stored.getFileName();
   if (name.isEmpty() || name == "." || name == "..")
     return stored;

--- a/plugin/src/WindowKeyEvents.mm
+++ b/plugin/src/WindowKeyEvents.mm
@@ -1,5 +1,20 @@
 #include "EditorWebViewSetup.h"
 
+#if JUCE_IOS
+
+namespace EditorWebViewSetup {
+
+// iOS has no host DAW to hand a transport keypress back to: the Standalone app
+// IS the host, and there is no AppKit event queue or NSResponder chain to post
+// a synthesized Space/Enter into. The UI still calls this (it suppresses the
+// key itself so nothing beeps or scrolls), so keep the symbol and make it a
+// no-op rather than teaching the UI a second platform check.
+void forwardKeyToHost(void*, HostKey) {}
+
+}  // namespace EditorWebViewSetup
+
+#else
+
 #import <AppKit/AppKit.h>
 
 namespace EditorWebViewSetup {
@@ -47,3 +62,5 @@ void forwardKeyToHost(void* nsViewPtr, HostKey key) {
 }
 
 }  // namespace EditorWebViewSetup
+
+#endif  // JUCE_IOS

--- a/plugin/src/WindowMouseEvents.mm
+++ b/plugin/src/WindowMouseEvents.mm
@@ -1,5 +1,13 @@
 #include "EditorWebViewSetup.h"
 
+// Everything in this file is AppKit: NSEvent injection, NSTrackingArea hover
+// revival, NSWindow background painting and the WKWebView context-menu guard.
+// None of it exists on iOS (there is no host DAW window to fight with, no
+// hover, no right-click), and EditorWebViewSetup.h only declares these entry
+// points under JUCE_MAC, so on iOS this translation unit is intentionally
+// empty rather than deleted: the macOS path below is byte-identical to before.
+#if JUCE_MAC
+
 #import <AppKit/AppKit.h>
 #import <WebKit/WebKit.h>
 
@@ -231,3 +239,5 @@ void setWebInspectorEnabled(void* nsViewPtr, bool enabled) {
 }
 
 }  // namespace EditorWebViewSetup
+
+#endif  // JUCE_MAC

--- a/test/src/local_load_tests.cpp
+++ b/test/src/local_load_tests.cpp
@@ -251,3 +251,40 @@ TEST(LocalLoadTest, PathRejectsBadInputs) {
   EXPECT_TRUE(firstToneBlock(proc).isVoid());
   dir.deleteRecursively();
 }
+
+// The stash path a block persists as its model_url is absolute, and the tone
+// JSON carrying it lives in presets, DAW/app state and undo snapshots. On iOS
+// the app data container's UUID rotates on every reinstall or app update, so
+// those paths name a container that is gone. Resolution therefore re-roots the
+// (content-hashed) file name under the current stash folder.
+TEST(LocalLoadTest, StashUrlResolvesUnderTheCurrentRoot) {
+  const juce::File tmp = juce::File::getSpecialLocation(juce::File::tempDirectory);
+  const juce::File root = tmp.getChildFile("t3k-stash-" + juce::Uuid().toString());
+  const juce::File live = root.getChildFile("deadbeef-4096.nam");
+  ASSERT_TRUE(root.createDirectory());
+  ASSERT_TRUE(live.replaceWithText("model bytes"));
+
+  // What a preset saved under a previous container holds.
+  const juce::String staleUrl =
+      juce::URL(tmp.getChildFile("Containers")
+                    .getChildFile(juce::Uuid().toString())
+                    .getChildFile("LocalModels")
+                    .getChildFile("deadbeef-4096.nam"))
+          .toString(false);
+  EXPECT_EQ(TONE3000Processor::resolveLocalModelFile(root, staleUrl), live);
+
+  // A path that still resolves comes back untouched: every desktop case.
+  EXPECT_EQ(TONE3000Processor::resolveLocalModelFile(root, juce::URL(live).toString(false)), live);
+
+  // Nothing to re-root for a catalog URL.
+  EXPECT_EQ(TONE3000Processor::resolveLocalModelFile(root, "https://test.invalid/model.nam"),
+            juce::File());
+
+  // Bytes that are gone everywhere still read as missing (the caller reports
+  // the failure), not as some other file.
+  EXPECT_FALSE(
+      TONE3000Processor::resolveLocalModelFile(root, staleUrl.replace("deadbeef", "0badc0de"))
+          .existsAsFile());
+
+  root.deleteRecursively();
+}

--- a/test/src/local_load_tests.cpp
+++ b/test/src/local_load_tests.cpp
@@ -288,3 +288,23 @@ TEST(LocalLoadTest, StashUrlResolvesUnderTheCurrentRoot) {
 
   root.deleteRecursively();
 }
+
+// The iOS document picker hands back URLs, whose last path component is
+// percent-escaped. Names must come back exactly as the desktop path derives
+// them from juce::File, or a file called "Deluxe Reverb 2.nam" loads (and
+// stashes, and titles its tile) as "Deluxe%20Reverb%202".
+TEST(LocalLoadTest, UrlFileNameIsPercentDecoded) {
+  const juce::File dir =
+      juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("t3k-name");
+  const juce::File spaced = dir.getChildFile("Deluxe Reverb 2.nam");
+  EXPECT_EQ(TONE3000Processor::localFileNameFromUrl(juce::URL(spaced)), "Deluxe Reverb 2.nam");
+
+  const juce::File accented = dir.getChildFile("Amplificador Válvulas.wav");
+  EXPECT_EQ(TONE3000Processor::localFileNameFromUrl(juce::URL(accented)),
+            juce::String::fromUTF8("Amplificador V\xc3\xa1lvulas.wav"));
+
+  // A non-file URL has no local file to ask, so the escapes come off the path.
+  EXPECT_EQ(TONE3000Processor::localFileNameFromUrl(
+                juce::URL("https://test.invalid/x/Deluxe%20Reverb%202.nam")),
+            "Deluxe Reverb 2.nam");
+}

--- a/test/src/local_load_tests.cpp
+++ b/test/src/local_load_tests.cpp
@@ -308,3 +308,79 @@ TEST(LocalLoadTest, UrlFileNameIsPercentDecoded) {
                 juce::URL("https://test.invalid/x/Deluxe%20Reverb%202.nam")),
             "Deluxe Reverb 2.nam");
 }
+
+// The iOS picker path. Compiled on every platform (the DSP suite does not
+// build for iOS), fed file:// URLs here, security-scoped ones on the iPad; the
+// bytes come through juce::URL::createInputStream either way. Multi-select is
+// the folder route on iOS, so it must sort, filter and aggregate errors the
+// way loadLocalTonePath does for a folder.
+TEST(LocalLoadTest, UrlsLoadMultiSelectInNaturalOrderSkippingBadFiles) {
+  const juce::File dir =
+      juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("t3k-url-test");
+  dir.deleteRecursively();
+  ASSERT_TRUE(dir.createDirectory().wasOk());
+  ASSERT_TRUE(testFile("a2-amp-test.nam").copyFileTo(dir.getChildFile("amp 2.nam")));
+  ASSERT_TRUE(testFile("a2-amp-cab-test.nam").copyFileTo(dir.getChildFile("amp 10.nam")));
+  ASSERT_TRUE(testFile("a2-am-test-2.nam").copyFileTo(dir.getChildFile("amp 1.nam")));
+  ASSERT_TRUE(dir.getChildFile("notes.txt").replaceWithText("hi"));
+
+  // Picker order is arbitrary; hand them over scrambled, with a wrong type and
+  // a file that does not exist mixed in.
+  TONE3000Processor proc;
+  const juce::var res = proc.loadLocalToneUrls({
+      juce::URL(dir.getChildFile("amp 10.nam")),
+      juce::URL(dir.getChildFile("notes.txt")),
+      juce::URL(dir.getChildFile("amp 2.nam")),
+      juce::URL(dir.getChildFile("missing.nam")),
+      juce::URL(dir.getChildFile("amp 1.nam")),
+  });
+  EXPECT_TRUE(res["error"].isVoid()) << res["error"].toString().toStdString();
+  ASSERT_TRUE(waitForChainLoaded(proc));
+
+  const juce::var block = firstToneBlock(proc);
+  EXPECT_EQ(block["tone"]["title"].toString(), juce::String("5 files"));
+  EXPECT_EQ(block["tone"]["format"].toString(), juce::String("nam"));
+  ASSERT_EQ(block["tone"]["models"].size(), 3)
+      << "models: " << juce::JSON::toString(block["tone"]["models"]).toStdString();
+  EXPECT_EQ(block["tone"]["models"][0]["name"].toString(), juce::String("amp 1"));
+  EXPECT_EQ(block["tone"]["models"][1]["name"].toString(), juce::String("amp 2"));
+  EXPECT_EQ(block["tone"]["models"][2]["name"].toString(), juce::String("amp 10"));
+
+  dir.deleteRecursively();
+}
+
+TEST(LocalLoadTest, UrlsSingleFileTitlesFromNameAndRejectBadInputs) {
+  TONE3000Processor proc;
+
+  // One file: the title is its name without the extension, as on desktop.
+  juce::var res = proc.loadLocalToneUrls({juce::URL(testFile("a2-amp-test.nam"))});
+  EXPECT_TRUE(res["error"].isVoid()) << res["error"].toString().toStdString();
+  ASSERT_TRUE(waitForChainLoaded(proc));
+  EXPECT_EQ(firstToneBlock(proc)["tone"]["title"].toString(), juce::String("a2-amp-test"));
+
+  TONE3000Processor rejecting;
+  res = rejecting.loadLocalToneUrls({});
+  EXPECT_EQ(res["error"].toString(), juce::String("Nothing to load"));
+
+  res = rejecting.loadLocalToneUrls({juce::URL(juce::File("/nonexistent-t3k/missing.nam"))});
+  EXPECT_EQ(res["error"].toString(), juce::String("Couldn't read the file"));
+
+  const juce::File dir =
+      juce::File::getSpecialLocation(juce::File::tempDirectory).getChildFile("t3k-url-reject");
+  dir.deleteRecursively();
+  ASSERT_TRUE(dir.createDirectory().wasOk());
+  ASSERT_TRUE(dir.getChildFile("notes.txt").replaceWithText("hi"));
+  res = rejecting.loadLocalToneUrls({juce::URL(dir.getChildFile("notes.txt"))});
+  EXPECT_EQ(res["error"].toString(), juce::String("Only .nam and .wav files are supported"));
+
+  // The folder cap (300 files) applies to a multi-select too. Nothing is read
+  // before the cap fires, so the URLs need not exist.
+  juce::Array<juce::URL> many;
+  for (int i = 0; i < 301; ++i)
+    many.add(juce::URL(dir.getChildFile("amp " + juce::String(i) + ".nam")));
+  res = rejecting.loadLocalToneUrls(many);
+  EXPECT_EQ(res["error"].toString(), juce::String("Too many files (max 300)"));
+
+  EXPECT_TRUE(firstToneBlock(rejecting).isVoid());
+  dir.deleteRecursively();
+}


### PR DESCRIPTION
## Summary

Adds an iOS / iPadOS Standalone target (Refs #55), build enablement only. iOS behaviour is behind `T3K_IOS` in CMake or `#if JUCE_IOS` in C++. Three pieces are shared on purpose and are called out below, everything else leaves macOS, Windows and Linux untouched. Rebased on current `main` (includes `-fsigned-char`, Linux aarch64 and the old-WebKit drag-and-drop fix).

What is in this PR, one commit each:

- `build(ios)`: `T3K_IOS` switch, formats reduced to Standalone on iOS, `NeuralAmpModelerCore` linked directly, iOS plist keys (microphone, background audio, file sharing, document browser, landscape), `T3K_IOS_BUNDLE_ID` cache variable, two CMake presets (`ios-simulator`, `ios-device`), and a fix for the `-force_load` generator expression, which only matched `Darwin` and silently dropped the NAM model registry on iOS.
- `fix(ios)`: the AppKit-only sources (`WindowMouseEvents.mm` wrapped in `#if JUCE_MAC`, `WindowKeyEvents.mm` no-op on iOS, `AudioPermissions.mm` on `AVAudioSession`).
- `fix(ios)`: the editor no longer applies the desktop aspect lock under JUCE's kiosk window (it resolved by height and pushed a third of the UI off screen).
- `fix(ios)`: file picker results are read through security-scoped URLs (`getURLResults()` + `URL::createInputStream`), multi-select replaces folder import on iOS (a security-scoped directory cannot be enumerated).
- `fix(ios)`: local model paths persisted in presets, state and undo snapshots are resolved against the current app container; the iOS data container UUID rotates on every reinstall and app update.
- `fix(ios)`: picker file names are percent-decoded before they become titles, model names and stash names.
- `test(local-load)`: the URL load path (`loadLocalToneUrls`, `stashLocalFileFromUrl`) is compiled on every platform so the DSP suite can cover it; only the iOS editor calls it. Two tests: a scrambled multi-select with a wrong type and a missing file, and the single-file title plus rejections and the 300-file cap.
- `docs`: what the stash re-rooting changes on desktop; iOS in `AudioPermissions.h`.
- `build(ios)`: a `FATAL_ERROR` when `CMAKE_SYSTEM_NAME=iOS` arrives too late for the `T3K_IOS` switch (toolchain file), `T3K_IOS_BUNDLE_ID` scoped to iOS, explicit `build-ios/` and `build-ios-device/` in `.gitignore`, `ios-simulator` preset without a meaningless `CMAKE_BUILD_TYPE` (Xcode is multi-config).
- `docs/ios.md`: how to configure, build, install, and what is still missing.

Shared code, not gated, and why:

- `TONE3000Processor::resolveLocalModelFile`: a stored stash path that exists comes back untouched, which is every path this machine wrote. A preset or saved state carrying a stash URL from another machine or account (the path is gone here too) now re-roots into the local stash and `refreshLocalStashCopy` writes the embedded bytes there, where before it returned early and every load read the embedded cache. Same bytes, one more file on disk. Stash names are content hashes, so the re-rooting is exact.
- `TONE3000Processor::localFileNameFromUrl`: pure helper, tested.
- `loadLocalToneUrls` / `stashLocalFileFromUrl`: compiled everywhere for the tests, unreachable on desktop (the only call site is under `#if JUCE_IOS` in `Editor.cpp`).

Out of scope here, coming in a second PR once this lands: the touch adaptation of the UI (fill the 1366 x 1024 pt screen, 44 pt targets, hold-to-lift reorder, visible tile menu button, "On this iPad" import section, haptics), Bluetooth MIDI verification on device, AUv3.

Known gaps on this branch (also in `docs/ios.md`): the UI is still the desktop UI, so on an iPad the fourth chain tile is clipped and the local file picker is reachable only through drag and drop from Files until the touch PR lands; nothing has been tested on iPhone; audio was verified only up to `prepareToPlay` at 48 kHz on a physical iPad Pro 12.9, not with a USB interface.

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [x] DSP: `./script/test-dsp.sh` on the head of this branch (`b11ce99`), macOS Release: 133 tests, 21 suites, all passing, including the four new `LocalLoadTest` cases (`StashUrlResolvesUnderTheCurrentRoot`, `UrlFileNameIsPercentDecoded`, `UrlsLoadMultiSelectInNaturalOrderSkippingBadFiles`, `UrlsSingleFileTitlesFromNameAndRejectBadInputs`)
- [x] UI: N/A, no `ui/` change
- [ ] Host validators: not run. The one desktop behaviour change is the cross-machine preset case of `resolveLocalModelFile` described above; it is covered by `StashUrlResolvesUnderTheCurrentRoot`
- [x] Host smoke: macOS Standalone rebuilt and launched on the head; **Build Plugin** workflow green on macOS Universal, Windows x64 and Linux x64 on the head (fork run: `https://github.com/brunofgsaraiva/tone3000-plugin/actions/runs/33860943665`); iOS Simulator (iPad Pro 12.9) configures and builds Release on the head; signed Release build installs and launches on a physical iPad Pro 12.9 6th gen (iPadOS 26); the `iOS Simulator` job is green on the fork (run: `https://github.com/brunofgsaraiva/tone3000-plugin/actions/runs/34111886634`)

Build for iOS:

```sh
cmake --preset ios-simulator && cmake --build build-ios --config Release --target TONE3000_Standalone -- -sdk iphonesimulator
cmake --preset ios-device -DT3K_IOS_BUNDLE_ID=<your.bundle.id> && cmake --build build-ios-device --config Release --target TONE3000_Standalone -- -sdk iphoneos -allowProvisioningUpdates
```

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why. No DSP behaviour change.

## Compatibility

- [x] AU parameter version hints in `Processor.cpp` are not reused or renumbered (file untouched)
- [x] Preset format unchanged (persisted `model_url` stays an absolute `file://` URL; older presets keep loading)
- [x] Desktop installer and plugin formats unchanged

## Questions for maintainers

1. Bundle id and display name for an official iOS build (`T3K_IOS_BUNDLE_ID` defaults to `com.TONE3000.TONE3000`).
2. Deployment target: iOS 16.0 chosen; happy to raise.
3. CI: an `iOS Simulator` job in `build.yml` configures and builds the Simulator target on a macOS runner and uploads the unsigned `.app` (included here, per your comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

