### PR TITLE
fix drag-and-drop on old WebKit and make forwarded webview errors rea…

### DIFF
--- a/plugin/src/EditorWebViewSetup.cpp
+++ b/plugin/src/EditorWebViewSetup.cpp
@@ -788,14 +788,29 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
             // Forward WebView console output to the native logger so it is
             // captured in the on-disk log even in release builds.
             (function () {
+              // Error fields are non-enumerable, so JSON.stringify(err) is
+              // '{}', which hides exactly what a crash report needs. Unwrap
+              // by hand, and duck-type rather than instanceof so cross-realm
+              // errors survive too.
+              const describe = (p) => {
+                if (typeof p === 'string') return p;
+                if (p && typeof p.message === 'string' && typeof p.stack === 'string')
+                  return (p.name || 'Error') + ': ' + p.message + '\n' + p.stack;
+                try {
+                  const json = JSON.stringify(p);
+                  if (json !== undefined && json !== '{}') return json;
+                } catch (e) {
+                  return String(p);
+                }
+                // DOM events and other exotic objects also stringify to '{}'.
+                // Naming the type keeps the line worth reading.
+                const type = p && p.constructor && p.constructor.name;
+                return (type || typeof p) + ' ' + String(p);
+              };
+
               const forward = (level, parts) => {
                 try {
-                  const text = parts
-                    .map((p) => {
-                      if (typeof p === 'string') return p;
-                      try { return JSON.stringify(p); } catch (e) { return String(p); }
-                    })
-                    .join(' ');
+                  const text = parts.map(describe).join(' ');
                   // The raw __juce__invoke protocol (what getNativeFunction
                   // wraps). window.__JUCE__.backend only exists once the app
                   // bundle has loaded (it's defined by the JUCE frontend
@@ -824,14 +839,19 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
                 };
               });
               window.addEventListener('error', (e) => {
-                forward('error', [e.message + ' @ ' + e.filename + ':' + e.lineno]);
+                forward('error', [e.message + ' @ ' + e.filename + ':' + e.lineno +
+                                  (e.error ? '\n' + describe(e.error) : '')]);
               });
               window.addEventListener('unhandledrejection', (e) => {
-                forward('error', ['Unhandled promise rejection: ' + (e.reason && e.reason.stack ? e.reason.stack : e.reason)]);
+                forward('error', ['Unhandled promise rejection: ' + describe(e.reason)]);
               });
             })();
 
-            console.log("Main WebView: JUCE C++ Backend loaded");
+            // The webview runs the system WebKit on macOS, and its version
+            // decides which language and DOM features exist, so record the
+            // engine with every load; the boot watchdog in index.html only
+            // logs it when the UI fails to boot.
+            console.log("Main WebView: JUCE C++ Backend loaded | " + navigator.userAgent);
           )");
 }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -46,6 +46,49 @@
         }, 4000);
       })();
     </script>
+    <script>
+      // Old WebKit does not carry the subclass prototype through
+      // `class X extends AbortController`: super() hands back a plain
+      // AbortController, so X's own methods are missing from the instance.
+      // dnd-kit's ActivationController extends it, so on macOS 10.15 every
+      // pointerdown on a draggable threw "onEvent is not a function" and
+      // drag-and-drop was dead (#34). Swap in a plain-JS controller that
+      // delegates to the native one, since ordinary classes subclass fine.
+      //
+      // Classic script in its own tag, ES5 syntax: it must run before the
+      // module bundle defines those classes, and a parse error here must not
+      // take the boot watchdog with it.
+      (function () {
+        var Native = window.AbortController;
+        if (!Native || typeof Reflect === 'undefined' || !Reflect.construct) return;
+
+        function subclassKeepsItsPrototype() {
+          try {
+            function Sub() {}
+            Sub.prototype = Object.create(Native.prototype);
+            Sub.prototype.probe = function () { return true; };
+            // What `class Sub extends Native` does when it calls super().
+            return typeof Reflect.construct(Native, [], Sub).probe === 'function';
+          } catch (err) {
+            return false;
+          }
+        }
+
+        if (subclassKeepsItsPrototype()) return;
+
+        function AbortControllerShim() {
+          var inner = new Native();
+          this.signal = inner.signal;
+          this.nativeController = inner;
+        }
+        // On the prototype, not the instance: subclasses call super.abort().
+        AbortControllerShim.prototype.abort = function (reason) {
+          this.nativeController.abort(reason);
+        };
+        window.AbortController = AbortControllerShim;
+        console.warn('[compat] native AbortController is not subclassable; installed shim');
+      })();
+    </script>
   </head>
   <body style="background-color: #000000;">
     <div id="root"></div>


### PR DESCRIPTION
…dable (#34)

## Summary

Fix old webkit bugs with shims

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
