### PR TITLE
Feat/linux aarch64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,10 @@ jobs:
             runs-on: ubuntu-24.04
             os: linux
             arch: x64
+          - name: Linux aarch64
+            runs-on: ubuntu-24.04-arm
+            os: linux
+            arch: aarch64
 
     steps:
       - name: Checkout
@@ -517,7 +521,7 @@ jobs:
           signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE }}
           files-folder: ${{ github.workspace }}\build
-          files-folder-filter: '*-setup.exe'
+          files-folder-filter: "*-setup.exe"
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
@@ -535,7 +539,7 @@ jobs:
         if: matrix.os == 'linux'
         run: |
           set -euo pipefail
-          PKG="TONE3000-v${T3K_VERSION}-linux-x64"
+          PKG="TONE3000-v${T3K_VERSION}-${{ matrix.os }}-${{ matrix.arch }}"
           ARTEFACTS="build/plugin/TONE3000_artefacts/${{ env.BUILD_TYPE }}"
           STAGE="build/${PKG}"
           mkdir -p "$STAGE"
@@ -558,5 +562,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: TONE3000-v${{ env.T3K_VERSION }}-${{ matrix.os }}-${{ matrix.arch }}
-          path: build/TONE3000-v*-linux-x64.tar.gz
+          path: build/TONE3000-v*-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
           if-no-files-found: error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
 
 # C is required since JUCE 9 (lunasvg and other C dependencies).
 project(TONE3000 VERSION ${T3K_VERSION} LANGUAGES C CXX)
+add_compile_options(-fsigned-char)
 
 set(CMAKE_CXX_STANDARD 20)
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)


### PR DESCRIPTION
## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
