### PR TITLE
[WIP needs QA on Win10] bootstrap the WebView2 runtime in the Windows installer when missing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ NAM processing comes from **NeuralAmpModelerCore** (in-tree), resampling from
 - [CMake](https://cmake.org/download/) 3.22+ and Git
 - Node.js and npm (the React UI is built after CMake has fetched JUCE)
 - **JUCE** is fetched automatically by CMake into `libs/`; no manual install
-- **Windows only:** [WebView2](https://developer.microsoft.com/en-us/microsoft-edge/webview2/)
-  runtime (`script/install-webview2.ps1` installs it). That is the native
-  browser the plugin UI runs in on Windows, not the TypeScript package
-  used to compile the UI.
+- **Windows only:** the Microsoft.Web.WebView2 SDK NuGet package
+  (`script/install-webview2.ps1` installs it), needed at build time to
+  statically link the WebView2 loader. At run time the plugin UI needs the
+  [WebView2 Evergreen Runtime](https://developer.microsoft.com/en-us/microsoft-edge/webview2/):
+  Windows 11 ships it, dev machines get it with Edge, and the release
+  installer bootstraps it when missing (typically clean Windows 10).
 
 ## Quick start
 
@@ -160,9 +162,11 @@ land in `build/plugin/TONE3000_artefacts/<config>/<format>/`.
 
 ## Linux runtime dependencies
 
-Windows links WebView2 statically and macOS uses the OS WKWebView, but the
-Linux build renders its UI in the system WebKitGTK, loaded dynamically at
-runtime. If it's missing, the plugin window is a black screen.
+Windows statically links only the WebView2 loader (the Evergreen Runtime is
+a system component; the installer bootstraps it when missing) and macOS uses
+the OS WKWebView, but the Linux build renders its UI in the system WebKitGTK,
+loaded dynamically at runtime. If it's missing, the plugin window is a black
+screen.
 
 Required: WebKitGTK 4.1 (or 4.0), GTK3, ALSA, FreeType.
 

--- a/script/installer/windows/tone3000.iss
+++ b/script/installer/windows/tone3000.iss
@@ -101,4 +101,91 @@ Type: files; Name: "{commonappdata}\TONE3000\Presets\Factory\*.t3kpreset"; Compo
 Name: "{autoprograms}\TONE3000"; Filename: "{app}\TONE3000.exe"; Components: standalone
 
 [Run]
+; Install the Microsoft Edge WebView2 Evergreen Runtime when it's missing
+; (typical on Windows 10; Windows 11 ships it). The plugin UI on Windows is
+; a WebView2 view - without the runtime JUCE silently falls back to the old
+; IE control, which can't serve the embedded https://juce.backend/ UI, and
+; every format shows a white screen (issue #54). The ~2 MB Evergreen
+; Bootstrapper is downloaded when the user clicks Install (see [Code]); it
+; then downloads and installs the runtime itself, so this step needs
+; internet access. Setup runs elevated (PrivilegesRequired=admin), so
+; /silent /install performs a per-machine install. Runs before the
+; postinstall launch entry below, so the first launch already has it.
+Filename: "{tmp}\MicrosoftEdgeWebView2Setup.exe"; Parameters: "/silent /install"; StatusMsg: "Installing Microsoft Edge WebView2 Runtime..."; Check: ShouldRunWebView2Bootstrapper
 Filename: "{app}\TONE3000.exe"; Description: "Launch TONE3000"; Components: standalone; Flags: nowait postinstall skipifsilent
+
+[Code]
+// --- WebView2 Evergreen Runtime bootstrap (needs Inno Setup 6.1+) ---------
+//
+// Detection follows Microsoft's distribution guidance: the runtime is
+// installed when EdgeUpdate registers client {F3017226-FE2A-4295-8BDF-
+// 00C3A9A7E4C5} with a non-empty pv value that isn't 0.0.0.0.
+// https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution
+//
+// The bootstrapper is fetched at install time from Microsoft's permalink
+// instead of being bundled: it only gets downloaded on the machines that
+// actually lack the runtime, and bundling wouldn't buy offline installs
+// anyway (the bootstrapper itself downloads the full runtime). No SHA256
+// pin on the download: Microsoft rotates the bootstrapper binary in place.
+var
+  WebView2BootstrapperDownloaded: Boolean;
+  DownloadPage: TDownloadWizardPage;
+
+function WebView2RuntimeMissing: Boolean;
+var
+  Version: String;
+begin
+  // Per-machine install: EdgeUpdate is 32-bit, so on this x64-only installer
+  // the key lives in the WOW6432Node view (HKLM32). Per-user install: HKCU
+  // Software is not WOW-redirected, plain HKCU is correct.
+  Result := True;
+  if RegQueryStringValue(HKLM32, 'SOFTWARE\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+                         'pv', Version) and (Version <> '') and (Version <> '0.0.0.0') then
+    Result := False
+  else if RegQueryStringValue(HKCU, 'Software\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}',
+                              'pv', Version) and (Version <> '') and (Version <> '0.0.0.0') then
+    Result := False;
+end;
+
+function ShouldRunWebView2Bootstrapper: Boolean;
+begin
+  Result := WebView2BootstrapperDownloaded;
+end;
+
+procedure InitializeWizard;
+begin
+  DownloadPage := CreateDownloadPage('Microsoft Edge WebView2',
+                                     'Setup is downloading the WebView2 Runtime installer. TONE3000 needs it to display its interface.',
+                                     nil);
+end;
+
+function NextButtonClick(CurPageID: Integer): Boolean;
+begin
+  Result := True;
+  // Runs on the Install click (and is still invoked on silent installs,
+  // where Setup simulates the click).
+  if (CurPageID = wpReady) and WebView2RuntimeMissing then
+  begin
+    DownloadPage.Clear;
+    DownloadPage.Add('https://go.microsoft.com/fwlink/p/?LinkId=2124703', 'MicrosoftEdgeWebView2Setup.exe', '');
+    DownloadPage.Show;
+    try
+      try
+        DownloadPage.Download;
+        WebView2BootstrapperDownloaded := True;
+      except
+        if DownloadPage.AbortedByUser then
+          Log('WebView2 bootstrapper download aborted by user.')
+        else
+          Log('WebView2 bootstrapper download failed: ' + GetExceptionMessage);
+        // Don't fail the whole install over this: the plugin files are
+        // still worth installing, and the runtime can be added afterwards.
+        SuppressibleMsgBox('Setup could not download the Microsoft Edge WebView2 Runtime, which TONE3000 needs to display its interface.'
+                           + #13#10#13#10 + 'Please install it later from https://aka.ms/webview2',
+                           mbInformation, MB_OK, IDOK);
+      end;
+    finally
+      DownloadPage.Hide;
+    end;
+  end;
+end;


### PR DESCRIPTION
…(#54)

Windows 10 doesn't ship WebView2, and without it JUCE silently falls
back to the IE control, which can't serve the embedded plugin UI --
every format opens to a white screen. The installer now detects the
Evergreen Runtime via EdgeUpdate's registry key and, when absent,
downloads Microsoft's bootstrapper on Install and runs it silently
before first launch. Also clarifies in the README that
install-webview2.ps1 fetches the build-time SDK, not the runtime.

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
