### PR TITLE
Fix restored NAM oversampling mismatch during prepareToPlay

### DIFF
--- a/plugin/src/Processor.cpp
+++ b/plugin/src/Processor.cpp
@@ -708,17 +708,30 @@ void TONE3000Processor::prepareToPlay(double sampleRate, int samplesPerBlock) {
   // Resolve the requested factor before anything chain-domain is sized: the
   // domain block size and rate both depend on it. Hosts re-run prepareToPlay
   // freely, so this also picks up a factor restored from session state.
-  chainOversampleFactor.store(resolvedOversampleFactor());
-  chainOversampler.prepare(chainOversampleFactor.load(), juce::jmax(1, chainBaseBlockSize()));
-  DBG("Chain oversampling ×" << chainOversampleFactor.load() << " (chain rate: "
-      << chainSampleRate() << " Hz)");
-
   // Prepare every engine in both lanes for the chain domain (fixed rate; the
   // domain block size depends on the host rate/block size).
   {
     juce::ScopedLock lock(chainMutex);
-    for (auto& l : lanes)
+    chainOversampleFactor.store(resolvedOversampleFactor());
+    chainOversampler.prepare(chainOversampleFactor.load(), juce::jmax(1, chainBaseBlockSize()));
+    DBG("Chain oversampling ×" << chainOversampleFactor.load() << " (chain rate: "
+        << chainSampleRate() << " Hz)");
+
+    for (auto& l : lanes) {
+      // Restore-time loads can land before the host resolves the saved
+      // factor here. prepare() cannot change an engine's phase count.
+      // In-flight loads already have a factor guard at installation.
+      for (auto& block : l) {
+        if (block->type == ChainBlockType::NAM && block->loaded && !block->modelLoading &&
+            block->namEngine != nullptr &&
+            block->namEngine->getOversampleFactor() != chainOversampleFactor.load()) {
+          block->loaded = false;
+          block->modelLoading = true;
+          queueActiveModelLoad(*block);
+        }
+      }
       prepareChain(l);
+    }
   }
 
   juce::dsp::ProcessSpec spec{sampleRate, static_cast<juce::uint32>(samplesPerBlock), 2};

--- a/test/src/processor_tests.cpp
+++ b/test/src/processor_tests.cpp
@@ -16,13 +16,14 @@
 //   - garbage, legacy-format, and newer-schema state blobs are ignored,
 //   - the tail report covers the DC blocker floor.
 //
-// No models/IRs are loaded here; chains stay empty, so nothing touches the
-// network. Runs on the message thread (ScopedJuceInitialiser_GUI in main).
+// Model tests use embedded local fixtures, so nothing touches the network.
+// Runs on the message thread (ScopedJuceInitialiser_GUI in main).
 // Oversampling parameter changes are applied via a re-prepare, exactly like
 // a host would (the live-toggle path is an AsyncUpdater that needs a running
 // message pump; prepareToPlay resolves the same parameters synchronously).
 #include "Processor.h"
 #include "test_helpers.h"
+#include "chain_test_helpers.h"
 
 #include <gtest/gtest.h>
 
@@ -266,6 +267,50 @@ TEST(ProcessorTest, ParameterStateSurvivesSaveRestore) {
   b.setPlayConfigDetails(2, 2, kFs, 512);
   b.prepareToPlay(kFs, 512);
   EXPECT_EQ(b.getLatencySamples(), 0);
+}
+
+TEST(ProcessorTest, RestoredNamsBeforePrepareMatchNamsLoadedAtFourTimes) {
+  juce::MemoryBlock saved;
+  {
+    ChainTestProcessor source;
+    juce::ValueTree snapshot("ChainSnapshot"), chain("ChainBlocks");
+    chain.appendChild(makeNamBlockTree("first", 1, 101), nullptr);
+    chain.appendChild(makeNamBlockTree("second", 2, 102, "a2-am-test-2.nam"), nullptr);
+    snapshot.appendChild(chain, nullptr);
+    source.restoreFromTree(snapshot);
+    ASSERT_TRUE(waitForChainLoaded(source));
+    source.parameters.getParameter("osEnabled")->setValueNotifyingHost(1.0f);
+    source.parameters.getParameter("osFactor")->setValueNotifyingHost(0.5f);  // 4x
+    source.getStateInformation(saved);
+  }
+
+  const auto input = makeNoise(96 * 512, 42, 0.05f);
+  auto renderRestored = [&]() {
+    TONE3000Processor proc;
+    proc.setStateInformation(saved.getData(), static_cast<int>(saved.getSize()));
+    EXPECT_TRUE(waitForChainLoaded(proc));  // engines installed at the initial 1x
+    proc.setPlayConfigDetails(2, 2, kFs, 512);
+    proc.prepareToPlay(kFs, 512);
+    EXPECT_TRUE(waitForChainLoaded(proc));
+    return processThrough(proc, input, 512);
+  };
+  const auto restored = renderRestored();
+
+  TONE3000Processor reference;
+  reference.parameters.getParameter("osEnabled")->setValueNotifyingHost(1.0f);
+  reference.parameters.getParameter("osFactor")->setValueNotifyingHost(0.5f);
+  reference.setPlayConfigDetails(2, 2, kFs, 512);
+  reference.prepareToPlay(kFs, 512);
+  reference.setStateInformation(saved.getData(), static_cast<int>(saved.getSize()));
+  ASSERT_TRUE(waitForChainLoaded(reference));
+  const auto expected = processThrough(reference, input, 512);
+  float maxDiff = 0.0f, peak = 0.0f;
+  for (size_t i = 16384; i < expected.size(); ++i) {
+    maxDiff = std::max(maxDiff, std::abs(restored[i] - expected[i]));
+    peak = std::max(peak, std::abs(expected[i]));
+  }
+  ASSERT_GT(peak, 1e-5f);
+  EXPECT_LT(maxDiff, 1e-5f);
 }
 
 TEST(ProcessorTest, IgnoresGarbageLegacyAndNewerSchemaState) {


### PR DESCRIPTION
I noticed a undeterministic problem when loading multiple mac os AU plugin instances on a M1 machine. Each having multiple NAMs when 4x oversampling was enabled (e.g., overdrive and amp). The problem was that some of the instances seemed to have a strange phase problem.

The issue seems to be that NAM engines can finish loading from a restored project before prepareToPlay resolves the saved oversampling factor. prepareToPlay previously updated the chain factor and reset existing engines without rebuilding their phase instances. This could leave a 1× engine processing a 4× chain until a model reload or oversampling change rebuilt it, with different NAM blocks affected depending on load timing.

This change checks loaded NAM engines in both lanes during prepareToPlay and queues a cache-first rebuild only when their factor differs from the chain. Publishing the chain factor and checking engines now happen under chainMutex, which also protects model installation. In-flight loads retain the existing installation-time factor guard.

Adds a regression test using two embedded NAM fixtures: models restored and fully loaded before the first prepareToPlay must produce the same settled audio as models loaded after preparing at 4×. No new fixtures or build changes.

To run on a configured development machine:
```sh
./script/test-dsp.sh 'ProcessorTest.*'
```

This test fails with the current git head, but works with the proposed change. I have also manually validated using AU plugin in Mac OS.

All the existing tests also PASS with this change.
