### PR TITLE
iOS: put the audio session in Measurement mode so the input reaches the model raw

### DIFF
--- a/plugin/include/StandaloneAudioSettings.h
+++ b/plugin/include/StandaloneAudioSettings.h
@@ -137,6 +137,10 @@ private:
   bool applyRememberedSetup(const juce::var& saved);
   void rememberCurrentSetup();
 
+  /** iOS: hold the audio session in Measurement mode (see the .cpp). Does
+      nothing on any other platform. */
+  void applyRawInputMode();
+
   /** Follow the feedback-risk heuristic unless the user has overridden. */
   void applyMonitoringPolicy();
   bool computeFeedbackRisk() const;

--- a/plugin/src/StandaloneAudioSettings.cpp
+++ b/plugin/src/StandaloneAudioSettings.cpp
@@ -816,15 +816,19 @@ void StandaloneAudioSettings::applyRawInputMode() {
   // AVAudioSession.inputLatency, the figure the settings UI reports.
   // setAudioPreprocessingEnabled(false) is Measurement mode, the raw path.
   //
-  // The mode belongs to the session and setCategory: clears it, which JUCE
-  // does again on every device open and route change - hence re-applying it
-  // here rather than once at startup. On a USB route restart the first
-  // setMode: can be dropped while the route is still settling, so a refusal
-  // is retried once.
-  if (!device->setAudioPreprocessingEnabled(false) &&
-      !device->setAudioPreprocessingEnabled(false))
-    juce::Logger::writeToLog(
-        "[Audio] iOS Measurement mode refused; the input stays pre-processed");
+  // setCategory: clears the session mode, and JUCE calls it every time a
+  // device opens, so this cannot be done once at startup. Device opens and
+  // route changes both end up at the device manager's change broadcast, which
+  // is where this is re-applied from.
+  //
+  // The retry covers a USB route restart, where the first setMode: can be
+  // dropped while the route is still settling. Nothing is reported on a second
+  // refusal: JUCE returns `session.mode == mode`, an NSString pointer
+  // comparison rather than isEqualToString:, so a false is not evidence the
+  // mode failed to take, and a log built on it would send someone chasing a
+  // session that is already in Measurement mode.
+  if (!device->setAudioPreprocessingEnabled(false))
+    device->setAudioPreprocessingEnabled(false);
 #endif
 }
 

--- a/plugin/src/StandaloneAudioSettings.cpp
+++ b/plugin/src/StandaloneAudioSettings.cpp
@@ -116,6 +116,7 @@ StandaloneAudioSettings::StandaloneAudioSettings(TONE3000Processor& p,
   jassert(isAvailable());
   if (auto* dm = deviceManager())
     dm->addChangeListener(this);
+  applyRawInputMode();
   ensureInitialPolicies();
 }
 
@@ -133,6 +134,7 @@ void StandaloneAudioSettings::changeListenerCallback(juce::ChangeBroadcaster*) {
   // Fires for every device-manager change: our own setters, hot-plugs,
   // devices vanishing mid-session, vendor control panel edits. Re-run the
   // sync policies, then push the UI to re-pull state.
+  applyRawInputMode();
   ensureInitialPolicies();
   applyMonitoringPolicy();
   if (onDeviceStateChanged)
@@ -798,6 +800,32 @@ void StandaloneAudioSettings::rememberCurrentSetup() {
   if (auto* obj = remembered.getDynamicObject())
     obj->setProperty(currentSetupKey(), entryVar);
   p->setValue(kRememberedSetupsKey, juce::JSON::toString(remembered, true));
+}
+
+void StandaloneAudioSettings::applyRawInputMode() {
+#if JUCE_IOS
+  auto* dm = deviceManager();
+  auto* device = dm != nullptr ? dm->getCurrentAudioDevice() : nullptr;
+  if (device == nullptr)
+    return;
+
+  // JUCE opens the session with setCategory: and no mode, so it stays in
+  // AVAudioSessionModeDefault - the voice chain. Its AGC levels the guitar
+  // before the model ever sees it (pick attack and the guitar's volume knob
+  // stop coming through), and the processing inflates
+  // AVAudioSession.inputLatency, the figure the settings UI reports.
+  // setAudioPreprocessingEnabled(false) is Measurement mode, the raw path.
+  //
+  // The mode belongs to the session and setCategory: clears it, which JUCE
+  // does again on every device open and route change - hence re-applying it
+  // here rather than once at startup. On a USB route restart the first
+  // setMode: can be dropped while the route is still settling, so a refusal
+  // is retried once.
+  if (!device->setAudioPreprocessingEnabled(false) &&
+      !device->setAudioPreprocessingEnabled(false))
+    juce::Logger::writeToLog(
+        "[Audio] iOS Measurement mode refused; the input stays pre-processed");
+#endif
 }
 
 void StandaloneAudioSettings::applyMonitoringPolicy() {


### PR DESCRIPTION
Follow-up to #55 — the input-preprocessing item. It touches no file #60 touches, so it can land in any order and it doesn't shape the branch layout either way. If it's simpler for review, say so and I'll close this and hand the patch to @brunofgsaraiva for the touch PR instead.

### What

JUCE opens the iOS session with `setCategory:` and no mode, so it stays in `AVAudioSessionModeDefault` — the voice chain. Two consequences for a guitar input:

- An AGC levels the signal before the model ever sees it, so pick attack and the guitar's volume knob stop coming through. That's most of what playing through a capture is for.
- The added processing inflates `AVAudioSession.inputLatency`, which is the figure the settings UI reports.

`setAudioPreprocessingEnabled(false)` selects `AVAudioSessionModeMeasurement` (the mapping is in JUCE's `juce_Audio_ios.cpp`), which is the raw input path.

### Where

`StandaloneAudioSettings`, alongside the other device policies: applied from the constructor and re-applied on every device-manager change. It has to be re-applied — the mode belongs to the session and `setCategory:` clears it, and JUCE calls `setCategory:` again on every device open and route change.

A refusal is retried once. `setAudioPreprocessingEnabled` returns `session.mode == mode`, so it does report whether the mode actually took, and on a USB route restart the first `setMode:` can be dropped while the route is still settling. A second refusal logs and leaves the input pre-processed rather than reporting success it didn't get.

### Off iOS

The whole body is behind `JUCE_IOS`, and the base `AudioIODevice::setAudioPreprocessingEnabled` returns false on every other platform. Desktop is untouched.

### What I have and haven't verified

Verified: the JUCE 9.0.1 signature and the iOS implementation it lands on, and that nothing else in the tree sets the session mode.

Not verified: I have no Xcode on this machine (Command Line Tools only), so I haven't compiled the iOS target, and `main` has no iOS job yet to do it for me. The change is three API calls. Once #60 gives me something I can install I'll confirm it on an M4 iPad Pro against a USB interface — the dynamics difference is audible and the reported latency should drop.
