### PR TITLE
Route website issues to tone-3000-feature-requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Sign-in and browsing tones on TONE3000 go to [support@tone3000.com](mailto:support@tone3000.com), not here.
+        Sign-in, browsing tones, and anything else on tone3000.com go to [tone-3000/tone-3000-feature-requests](https://github.com/tone-3000/tone-3000-feature-requests/issues), not here.
 
   - type: checkboxes
     id: searched

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: TONE3000 website
+    url: https://github.com/tone-3000/tone-3000-feature-requests/issues
+    about: Bugs and feature requests for tone3000.com, including sign-in and the catalog.
   - name: TONE3000 support
     url: https://www.tone3000.com
-    about: Sign-in and catalog. Email support@tone3000.com. Not plugin bugs.
+    about: Email support@tone3000.com for account questions, takedowns, or anything private.
   - name: NAM Core
     url: https://github.com/sdatkinson/NeuralAmpModelerCore
     about: NAM inference library (vendored in this plugin).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/tone-3000/tone-3000-feature-requests/issues
     about: Bugs and feature requests for tone3000.com, including sign-in and the catalog.
   - name: TONE3000 support
-    url: https://www.tone3000.com
-    about: Email support@tone3000.com for account questions, takedowns, or anything private.
+    url: https://www.tone3000.com/changelog#report
+    about: Email or Discord, for account questions, takedowns, or anything private.
   - name: NAM Core
     url: https://github.com/sdatkinson/NeuralAmpModelerCore
     about: NAM inference library (vendored in this plugin).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/tone-3000/tone-3000-feature-requests/issues
     about: Bugs and feature requests for tone3000.com, including sign-in and the catalog.
   - name: TONE3000 support
-    url: https://www.tone3000.com/changelog#report
-    about: Email or Discord, for account questions, takedowns, or anything private.
+    url: https://www.tone3000.com
+    about: Email support@tone3000.com for account questions, takedowns, or anything private.
   - name: NAM Core
     url: https://github.com/sdatkinson/NeuralAmpModelerCore
     about: NAM inference library (vendored in this plugin).

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Sign-in, catalog browse, and tone3000.com go to [support@tone3000.com](mailto:support@tone3000.com), not here.
+        Sign-in, catalog browse, and anything else on tone3000.com go to [tone-3000/tone-3000-feature-requests](https://github.com/tone-3000/tone-3000-feature-requests/issues), not here.
 
   - type: checkboxes
     id: searched


### PR DESCRIPTION
Website bugs and requests now have a public repo of their own, so point at it from the contact links and the notes atop each form instead of sending people to support email.
