### PR TITLE
Preset UI improvements: categories, favourites, drag and drop, and bulk editing

### DIFF
--- a/plugin/include/PresetManager.h
+++ b/plugin/include/PresetManager.h
@@ -39,11 +39,14 @@ public:
   struct Info {
     juce::String id;
     juce::String name;
+    juce::String category;
+    bool favorite{false};
     bool factory{false};
   };
 
   static constexpr const char* kFileExtension = ".t3kpreset";
   static constexpr const char* kPresetTag = "T3KPreset";
+  static constexpr int kMaxCategoryNameLength = 50;
 
   PresetManager();
 
@@ -76,6 +79,36 @@ public:
       global order can't disagree. Persists the whole current order. */
   bool move(const juce::String& id, int delta) const;
 
+  /** User categories, sorted alphabetically (case-insensitive). */
+  juce::StringArray listCategories() const;
+
+  /** Add a user category (trimmed, non-empty, max 50 chars, case-insensitive unique). */
+  bool addCategory(const juce::String& name) const;
+
+  /** Delete a category. Existing presets in this category are moved to root (""). */
+  bool deleteCategory(const juce::String& name) const;
+
+  /** Assign a user preset to a category (empty string = root "Your Presets"). */
+  bool setPresetCategory(const juce::String& id, const juce::String& category) const;
+
+  /** Move multiple presets to a category. */
+  bool movePresetsToCategory(const juce::StringArray& ids, const juce::String& category) const;
+
+  /** Set favourite / starred status for a preset. */
+  bool setPresetFavorite(const juce::String& id, bool isFavorite) const;
+
+  /** Set favourite / starred status for multiple presets. */
+  bool setPresetsFavorite(const juce::StringArray& ids, bool isFavorite) const;
+
+  /** Duplicate a user preset with "Copy-" prepended to the name. */
+  Info duplicatePreset(const juce::String& id) const;
+
+  /** Duplicate multiple user presets with "Copy-" prepended. */
+  std::vector<Info> duplicatePresets(const juce::StringArray& ids) const;
+
+  /** Delete multiple user presets. */
+  bool removePresets(const juce::StringArray& ids) const;
+
 private:
   juce::File fileForId(const juce::String& id) const;
   static juce::File defaultSystemFactoryDir();
@@ -85,6 +118,14 @@ private:
   juce::File orderFile() const;
   juce::StringArray readOrder() const;
   bool writeOrder(const juce::StringArray& ids) const;
+
+  juce::File categoriesFile() const;
+  juce::StringArray readCategories() const;
+  bool writeCategories(const juce::StringArray& categories) const;
+
+  juce::File favoritesFile() const;
+  juce::StringArray readFavorites() const;
+  bool writeFavorites(const juce::StringArray& ids) const;
 
   juce::File userDir;
   juce::File factoryDir;        // user-local Factory/ (dev drops, Linux install)

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -384,6 +384,16 @@ public:
   // untouched) when the state is already at default.
   bool resetToDefault();
 
+  // Category and bulk preset operations
+  bool addPresetCategory(const juce::String& name);
+  bool deletePresetCategory(const juce::String& name);
+  bool setPresetCategory(const juce::String& id, const juce::String& category);
+  bool movePresetsToCategory(const juce::StringArray& ids, const juce::String& category);
+  bool setPresetFavorite(const juce::String& id, bool isFavorite);
+  bool setPresetsFavorite(const juce::StringArray& ids, bool isFavorite);
+  juce::var duplicatePresets(const juce::StringArray& ids);
+  bool deletePresets(const juce::StringArray& ids);
+
   // Tuner: enabled by the UI while the tuner screen is visible. Reads the raw
   // (pre-gain, pre-gate) input so gating never starves the pitch detector.
   void setTunerEnabled(bool enabled) { tuner.setEnabled(enabled); }

--- a/plugin/src/EditorWebViewSetup.cpp
+++ b/plugin/src/EditorWebViewSetup.cpp
@@ -450,6 +450,66 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
           "resetToDefault", guarded(0, false, [editor](const juce::Array<juce::var>&) {
             return juce::var(editor->processor.resetToDefault());
           }))
+      .withNativeFunction(
+          "addPresetCategory", guarded(1, false, [editor](const juce::Array<juce::var>& args) {
+            return juce::var(editor->processor.addPresetCategory(args[0].toString()));
+          }))
+      .withNativeFunction(
+          "deletePresetCategory", guarded(1, false, [editor](const juce::Array<juce::var>& args) {
+            return juce::var(editor->processor.deletePresetCategory(args[0].toString()));
+          }))
+      .withNativeFunction(
+          "setPresetCategory", guarded(2, false, [editor](const juce::Array<juce::var>& args) {
+            return juce::var(editor->processor.setPresetCategory(args[0].toString(), args[1].toString()));
+          }))
+      .withNativeFunction(
+          "movePresetsToCategory", guarded(2, false, [editor](const juce::Array<juce::var>& args) {
+            juce::StringArray ids;
+            if (const auto* arr = args[0].getArray()) {
+              for (const auto& item : *arr)
+                ids.add(item.toString());
+            } else {
+              ids.add(args[0].toString());
+            }
+            return juce::var(editor->processor.movePresetsToCategory(ids, args[1].toString()));
+          }))
+      .withNativeFunction(
+          "setPresetFavorite", guarded(2, false, [editor](const juce::Array<juce::var>& args) {
+            return juce::var(editor->processor.setPresetFavorite(args[0].toString(), static_cast<bool>(args[1])));
+          }))
+      .withNativeFunction(
+          "setPresetsFavorite", guarded(2, false, [editor](const juce::Array<juce::var>& args) {
+            juce::StringArray ids;
+            if (const auto* arr = args[0].getArray()) {
+              for (const auto& item : *arr)
+                ids.add(item.toString());
+            } else {
+              ids.add(args[0].toString());
+            }
+            return juce::var(editor->processor.setPresetsFavorite(ids, static_cast<bool>(args[1])));
+          }))
+      .withNativeFunction(
+          "duplicatePresets", guarded(1, juce::var(), [editor](const juce::Array<juce::var>& args) {
+            juce::StringArray ids;
+            if (const auto* arr = args[0].getArray()) {
+              for (const auto& item : *arr)
+                ids.add(item.toString());
+            } else {
+              ids.add(args[0].toString());
+            }
+            return editor->processor.duplicatePresets(ids);
+          }))
+      .withNativeFunction(
+          "deletePresets", guarded(1, false, [editor](const juce::Array<juce::var>& args) {
+            juce::StringArray ids;
+            if (const auto* arr = args[0].getArray()) {
+              for (const auto& item : *arr)
+                ids.add(item.toString());
+            } else {
+              ids.add(args[0].toString());
+            }
+            return juce::var(editor->processor.deletePresets(ids));
+          }))
       // --- Audio device settings (standalone only) ---------------------------
       // All of these route through the StandaloneAudioSettings controller,
       // which exists only under the standalone holder; in hosts they resolve

--- a/plugin/src/PresetManager.cpp
+++ b/plugin/src/PresetManager.cpp
@@ -344,7 +344,8 @@ bool PresetManager::deleteCategory(const juce::String& rawName) const {
     return false;
 
   categories.remove(foundIndex);
-  writeCategories(categories);
+  if (!writeCategories(categories))
+    return false;
 
   // If a category has existing presets within it, these presets go to the root "Your presets" instead of being deleted.
   for (const auto& file : userDir.findChildFiles(juce::File::findFiles, false, "*" + juce::String(kFileExtension))) {

--- a/plugin/src/PresetManager.cpp
+++ b/plugin/src/PresetManager.cpp
@@ -109,6 +109,8 @@ std::vector<PresetManager::Info> PresetManager::list() const {
       Info info;
       info.id = prefix + file.getFileNameWithoutExtension();
       info.name = preset.getProperty("name", file.getFileNameWithoutExtension()).toString();
+      info.category = preset.getProperty("category", "").toString();
+      info.favorite = static_cast<bool>(preset.getProperty("favorite", false));
       info.factory = factory;
       out.push_back(std::move(info));
     }
@@ -157,6 +159,13 @@ std::vector<PresetManager::Info> PresetManager::list() const {
       return rank(a) < rank(b);
     });
   }
+
+  const juce::StringArray favs = readFavorites();
+  for (auto& p : presets) {
+    if (favs.contains(p.id))
+      p.favorite = true;
+  }
+
   return presets;
 }
 
@@ -263,5 +272,222 @@ bool PresetManager::rename(const juce::String& id, const juce::String& newName) 
 bool PresetManager::remove(const juce::String& id) const {
   if (!id.startsWith(kUserPrefix))
     return false;
+  juce::StringArray favs = readFavorites();
+  if (favs.contains(id)) {
+    favs.removeString(id);
+    writeFavorites(favs);
+  }
   return fileForId(id).deleteFile();
+}
+
+juce::File PresetManager::categoriesFile() const {
+  return userDir.getChildFile("categories.json");
+}
+
+juce::StringArray PresetManager::readCategories() const {
+  juce::StringArray out;
+  const auto parsed = juce::JSON::parse(categoriesFile().loadFileAsString());
+  if (const auto* arr = parsed.getArray()) {
+    for (const auto& item : *arr) {
+      const juce::String str = item.toString().trim();
+      if (str.isNotEmpty())
+        out.add(str);
+    }
+  }
+  out.sort(true);
+  return out;
+}
+
+bool PresetManager::writeCategories(const juce::StringArray& categories) const {
+  if (!userDir.createDirectory())
+    return false;
+  juce::Array<juce::var> list;
+  for (const auto& cat : categories)
+    list.add(cat);
+  return categoriesFile().replaceWithText(juce::JSON::toString(juce::var(list)));
+}
+
+juce::StringArray PresetManager::listCategories() const {
+  return readCategories();
+}
+
+bool PresetManager::addCategory(const juce::String& rawName) const {
+  const juce::String name = rawName.trim();
+  if (name.isEmpty() || name.length() > kMaxCategoryNameLength)
+    return false;
+
+  juce::StringArray categories = readCategories();
+  for (const auto& existing : categories) {
+    if (existing.compareIgnoreCase(name) == 0)
+      return false;
+  }
+
+  categories.add(name);
+  categories.sort(true);
+  return writeCategories(categories);
+}
+
+bool PresetManager::deleteCategory(const juce::String& rawName) const {
+  const juce::String name = rawName.trim();
+  if (name.isEmpty())
+    return false;
+
+  juce::StringArray categories = readCategories();
+  int foundIndex = -1;
+  for (int i = 0; i < categories.size(); ++i) {
+    if (categories[i].compareIgnoreCase(name) == 0) {
+      foundIndex = i;
+      break;
+    }
+  }
+  if (foundIndex < 0)
+    return false;
+
+  categories.remove(foundIndex);
+  writeCategories(categories);
+
+  // If a category has existing presets within it, these presets go to the root "Your presets" instead of being deleted.
+  for (const auto& file : userDir.findChildFiles(juce::File::findFiles, false, "*" + juce::String(kFileExtension))) {
+    juce::ValueTree preset = readPresetFile(file);
+    if (!preset.isValid())
+      continue;
+    const juce::String cat = preset.getProperty("category", "").toString();
+    if (cat.compareIgnoreCase(name) == 0) {
+      preset.removeProperty("category", nullptr);
+      writePresetFile(file, preset);
+    }
+  }
+
+  return true;
+}
+
+bool PresetManager::setPresetCategory(const juce::String& id, const juce::String& category) const {
+  if (!id.startsWith(kUserPrefix))
+    return false;
+
+  const juce::File file = fileForId(id);
+  juce::ValueTree preset = readPresetFile(file);
+  if (!preset.isValid())
+    return false;
+
+  const juce::String trimmed = category.trim();
+  if (trimmed.isEmpty())
+    preset.removeProperty("category", nullptr);
+  else
+    preset.setProperty("category", trimmed, nullptr);
+
+  return writePresetFile(file, preset);
+}
+
+bool PresetManager::movePresetsToCategory(const juce::StringArray& ids, const juce::String& category) const {
+  bool anyOk = false;
+  for (const auto& id : ids) {
+    if (setPresetCategory(id, category))
+      anyOk = true;
+  }
+  return anyOk;
+}
+
+juce::File PresetManager::favoritesFile() const {
+  return userDir.getChildFile("favorites.json");
+}
+
+juce::StringArray PresetManager::readFavorites() const {
+  juce::StringArray out;
+  const auto parsed = juce::JSON::parse(favoritesFile().loadFileAsString());
+  if (const auto* arr = parsed.getArray()) {
+    for (const auto& item : *arr) {
+      const juce::String str = item.toString().trim();
+      if (str.isNotEmpty())
+        out.add(str);
+    }
+  }
+  return out;
+}
+
+bool PresetManager::writeFavorites(const juce::StringArray& ids) const {
+  if (!userDir.createDirectory())
+    return false;
+  juce::Array<juce::var> list;
+  for (const auto& id : ids)
+    list.add(id);
+  return favoritesFile().replaceWithText(juce::JSON::toString(juce::var(list)));
+}
+
+bool PresetManager::setPresetFavorite(const juce::String& id, bool isFavorite) const {
+  return setPresetsFavorite(juce::StringArray{id}, isFavorite);
+}
+
+bool PresetManager::setPresetsFavorite(const juce::StringArray& ids, bool isFavorite) const {
+  if (ids.isEmpty())
+    return true;
+
+  juce::StringArray favs = readFavorites();
+  for (const auto& id : ids) {
+    if (isFavorite) {
+      if (!favs.contains(id))
+        favs.add(id);
+    } else {
+      favs.removeString(id);
+    }
+
+    if (id.startsWith(kUserPrefix)) {
+      const juce::File file = fileForId(id);
+      juce::ValueTree preset = readPresetFile(file);
+      if (preset.isValid()) {
+        preset.setProperty("favorite", isFavorite, nullptr);
+        writePresetFile(file, preset);
+      }
+    }
+  }
+  writeFavorites(favs);
+  return true;
+}
+
+PresetManager::Info PresetManager::duplicatePreset(const juce::String& id) const {
+  if (!id.startsWith(kUserPrefix))
+    return {};
+
+  const juce::File srcFile = fileForId(id);
+  juce::ValueTree preset = readPresetFile(srcFile);
+  if (!preset.isValid())
+    return {};
+
+  if (!userDir.createDirectory())
+    return {};
+
+  const juce::String originalName = preset.getProperty("name", "").toString();
+  const juce::String copyName = "Copy-" + originalName;
+  preset.setProperty("name", copyName, nullptr);
+
+  const juce::File dstFile = userDir.getChildFile(juce::Uuid().toString() + kFileExtension);
+  if (!writePresetFile(dstFile, preset))
+    return {};
+
+  Info info;
+  info.id = kUserPrefix + dstFile.getFileNameWithoutExtension();
+  info.name = copyName;
+  info.category = preset.getProperty("category", "").toString();
+  info.favorite = static_cast<bool>(preset.getProperty("favorite", false));
+  info.factory = false;
+  return info;
+}
+
+std::vector<PresetManager::Info> PresetManager::duplicatePresets(const juce::StringArray& ids) const {
+  std::vector<Info> out;
+  for (const auto& id : ids) {
+    const Info dup = duplicatePreset(id);
+    if (dup.id.isNotEmpty())
+      out.push_back(dup);
+  }
+  return out;
+}
+
+bool PresetManager::removePresets(const juce::StringArray& ids) const {
+  bool anyOk = false;
+  for (const auto& id : ids) {
+    if (remove(id))
+      anyOk = true;
+  }
+  return anyOk;
 }

--- a/plugin/src/ProcessorPresets.cpp
+++ b/plugin/src/ProcessorPresets.cpp
@@ -44,10 +44,17 @@ juce::var TONE3000Processor::getPresetList() const {
     obj->setProperty("id", info.id);
     obj->setProperty("name", info.name);
     obj->setProperty("factory", info.factory);
+    obj->setProperty("category", info.category);
+    obj->setProperty("favorite", info.favorite);
     presetArray.add(juce::var(obj.get()));
+  }
+  juce::Array<juce::var> categoryArray;
+  for (const auto& cat : presetManager.listCategories()) {
+    categoryArray.add(cat);
   }
   juce::DynamicObject::Ptr root = new juce::DynamicObject();
   root->setProperty("presets", presetArray);
+  root->setProperty("categories", categoryArray);
   return root.get();
 }
 
@@ -257,4 +264,62 @@ bool TONE3000Processor::resetToDefault() {
   juce::Logger::writeToLog("[Presets] Reset to default");
   // No deferred fade release: an empty chain queues no model loads.
   return true;
+}
+
+bool TONE3000Processor::addPresetCategory(const juce::String& name) {
+  return presetManager.addCategory(name);
+}
+
+bool TONE3000Processor::deletePresetCategory(const juce::String& name) {
+  return presetManager.deleteCategory(name);
+}
+
+bool TONE3000Processor::setPresetCategory(const juce::String& id, const juce::String& category) {
+  return presetManager.setPresetCategory(id, category);
+}
+
+bool TONE3000Processor::movePresetsToCategory(const juce::StringArray& ids, const juce::String& category) {
+  return presetManager.movePresetsToCategory(ids, category);
+}
+
+bool TONE3000Processor::setPresetFavorite(const juce::String& id, bool isFavorite) {
+  return presetManager.setPresetFavorite(id, isFavorite);
+}
+
+bool TONE3000Processor::setPresetsFavorite(const juce::StringArray& ids, bool isFavorite) {
+  return presetManager.setPresetsFavorite(ids, isFavorite);
+}
+
+juce::var TONE3000Processor::duplicatePresets(const juce::StringArray& ids) {
+  const auto created = presetManager.duplicatePresets(ids);
+  juce::Array<juce::var> result;
+  for (const auto& info : created) {
+    juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+    obj->setProperty("id", info.id);
+    obj->setProperty("name", info.name);
+    obj->setProperty("category", info.category);
+    obj->setProperty("favorite", info.favorite);
+    obj->setProperty("factory", info.factory);
+    result.add(juce::var(obj.get()));
+  }
+  return result;
+}
+
+bool TONE3000Processor::deletePresets(const juce::StringArray& ids) {
+  bool activeDeleted = false;
+  {
+    juce::ScopedLock lock(chainMutex);
+    for (const auto& id : ids) {
+      if (activePresetId == id) {
+        activePresetId.clear();
+        activePresetName.clear();
+        activeDeleted = true;
+        break;
+      }
+    }
+  }
+  if (activeDeleted)
+    bumpChainRevision();
+
+  return presetManager.removePresets(ids);
 }

--- a/test/src/preset_tests.cpp
+++ b/test/src/preset_tests.cpp
@@ -209,4 +209,170 @@ TEST(PresetManagerTest, MoveShiftsByDeltaWithinTheSection) {
   EXPECT_FALSE(mgr.move(d.id, -4));
 }
 
+TEST(PresetManagerTest, CategoryLifecycleAndSorting) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  EXPECT_TRUE(mgr.addCategory("Rock"));
+  EXPECT_TRUE(mgr.addCategory("ambient"));
+  EXPECT_TRUE(mgr.addCategory("Blues"));
+
+  // Duplicate (case-insensitive) is refused
+  EXPECT_FALSE(mgr.addCategory("rock"));
+  EXPECT_FALSE(mgr.addCategory("ROCK"));
+
+  // Empty or whitespace only is refused
+  EXPECT_FALSE(mgr.addCategory("   "));
+
+  // > 50 characters is refused
+  const juce::String tooLong(std::string(51, 'a'));
+  EXPECT_FALSE(mgr.addCategory(tooLong));
+
+  // 50 characters is allowed
+  const juce::String exactly50(std::string(50, 'b'));
+  EXPECT_TRUE(mgr.addCategory(exactly50));
+
+  // Sorted case-insensitively: ambient, bbbbb..., Blues, Rock
+  const auto categories = mgr.listCategories();
+  ASSERT_EQ(categories.size(), 4);
+  EXPECT_EQ(categories[0], juce::String("ambient"));
+  EXPECT_EQ(categories[1], exactly50);
+  EXPECT_EQ(categories[2], juce::String("Blues"));
+  EXPECT_EQ(categories[3], juce::String("Rock"));
+
+  // Survives fresh PresetManager instance (categories.json)
+  PresetManager fresh(tmp.dir);
+  EXPECT_EQ(fresh.listCategories(), categories);
+}
+
+TEST(PresetManagerTest, CategoryMultiLingualNames) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  EXPECT_TRUE(mgr.addCategory(juce::CharPointer_UTF8("リード・ギター")));
+  EXPECT_TRUE(mgr.addCategory(juce::CharPointer_UTF8("Café Rock 🎸")));
+  EXPECT_TRUE(mgr.addCategory(juce::CharPointer_UTF8("Schöne Töne")));
+
+  const auto categories = mgr.listCategories();
+  ASSERT_EQ(categories.size(), 3);
+  EXPECT_TRUE(categories.contains(juce::CharPointer_UTF8("リード・ギター")));
+  EXPECT_TRUE(categories.contains(juce::CharPointer_UTF8("Café Rock 🎸")));
+  EXPECT_TRUE(categories.contains(juce::CharPointer_UTF8("Schöne Töne")));
+}
+
+TEST(PresetManagerTest, PresetCategoryAssignmentAndMove) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  mgr.addCategory("Rock");
+  const auto p1 = mgr.save("Lead 1", makePreset("p1"));
+  const auto p2 = mgr.save("Rhythm 1", makePreset("p2"));
+
+  EXPECT_TRUE(mgr.setPresetCategory(p1.id, "Rock"));
+  EXPECT_TRUE(mgr.setPresetCategory(p2.id, "Rock"));
+
+  auto list = mgr.list();
+  ASSERT_EQ(list.size(), 2u);
+  EXPECT_EQ(list[0].category, juce::String("Rock"));
+  EXPECT_EQ(list[1].category, juce::String("Rock"));
+
+  // Move back to root (empty category)
+  EXPECT_TRUE(mgr.setPresetCategory(p1.id, ""));
+  list = mgr.list();
+  EXPECT_EQ(list[0].category, juce::String(""));
+}
+
+TEST(PresetManagerTest, DeleteCategoryMovesPresetsToRoot) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  mgr.addCategory("Clean");
+  const auto p1 = mgr.save("Warm Clean", makePreset("p1"));
+  const auto p2 = mgr.save("Bright Clean", makePreset("p2"));
+
+  mgr.setPresetCategory(p1.id, "Clean");
+  mgr.setPresetCategory(p2.id, "Clean");
+
+  // Deleting the category removes the category from the list
+  EXPECT_TRUE(mgr.deleteCategory("Clean"));
+  EXPECT_EQ(mgr.listCategories().size(), 0);
+
+  // But the presets are NOT deleted; their category is reset to root ("")
+  const auto list = mgr.list();
+  ASSERT_EQ(list.size(), 2u);
+  EXPECT_EQ(list[0].category, juce::String(""));
+  EXPECT_EQ(list[1].category, juce::String(""));
+  EXPECT_TRUE(mgr.load(p1.id).isValid());
+  EXPECT_TRUE(mgr.load(p2.id).isValid());
+}
+
+TEST(PresetManagerTest, FavoritesLifecycle) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  const auto p1 = mgr.save("Fav 1", makePreset("f1"));
+  const auto p2 = mgr.save("Normal 2", makePreset("f2"));
+
+  EXPECT_TRUE(mgr.setPresetFavorite(p1.id, true));
+
+  auto list = mgr.list();
+  ASSERT_EQ(list.size(), 2u);
+  EXPECT_TRUE(list[0].favorite);
+  EXPECT_FALSE(list[1].favorite);
+
+  // Survives fresh PresetManager instance
+  PresetManager fresh(tmp.dir);
+  list = fresh.list();
+  EXPECT_TRUE(list[0].favorite);
+  EXPECT_FALSE(list[1].favorite);
+
+  // Unstarring works
+  EXPECT_TRUE(fresh.setPresetFavorite(p1.id, false));
+  list = fresh.list();
+  EXPECT_FALSE(list[0].favorite);
+
+  // Batch starring and unstarring
+  juce::StringArray both;
+  both.add(p1.id);
+  both.add(p2.id);
+  EXPECT_TRUE(fresh.setPresetsFavorite(both, true));
+  list = fresh.list();
+  EXPECT_TRUE(list[0].favorite);
+  EXPECT_TRUE(list[1].favorite);
+
+  EXPECT_TRUE(fresh.setPresetsFavorite(both, false));
+  list = fresh.list();
+  EXPECT_FALSE(list[0].favorite);
+  EXPECT_FALSE(list[1].favorite);
+}
+
+TEST(PresetManagerTest, DuplicatePresetAndBatch) {
+  TempPresetDir tmp;
+  PresetManager mgr(tmp.dir);
+
+  mgr.addCategory("Metal");
+  const auto orig = mgr.save("Chug", makePreset("metal"));
+  mgr.setPresetCategory(orig.id, "Metal");
+
+  const auto dup = mgr.duplicatePreset(orig.id);
+  ASSERT_TRUE(dup.id.isNotEmpty());
+  EXPECT_NE(dup.id, orig.id);
+  EXPECT_EQ(dup.name, juce::String("Copy-Chug"));
+  EXPECT_EQ(dup.category, juce::String("Metal"));
+
+  const auto list = mgr.list();
+  ASSERT_EQ(list.size(), 2u);
+
+  // Duplicate a copy -> "Copy-Copy-Chug"
+  const auto dup2 = mgr.duplicatePreset(dup.id);
+  EXPECT_EQ(dup2.name, juce::String("Copy-Copy-Chug"));
+
+  // Batch delete
+  juce::StringArray toDelete;
+  toDelete.add(dup.id);
+  toDelete.add(dup2.id);
+  EXPECT_TRUE(mgr.removePresets(toDelete));
+  EXPECT_EQ(mgr.list().size(), 1u);
+}
+
 }  // namespace

--- a/ui/src/components/PluginHeader.tsx
+++ b/ui/src/components/PluginHeader.tsx
@@ -102,6 +102,7 @@ export const PluginHeader = React.memo(function PluginHeader({
         <PresetBar
           active={activePreset}
           presets={presetStore.presets}
+          categories={presetStore.categories}
           atDefault={atDefault}
           onSave={presetStore.actions.save}
           onLoad={presetStore.actions.load}
@@ -109,6 +110,14 @@ export const PluginHeader = React.memo(function PluginHeader({
           onDelete={presetStore.actions.remove}
           onMove={presetStore.actions.move}
           onReset={onReset}
+          onAddCategory={presetStore.actions.addCategory}
+          onDeleteCategory={presetStore.actions.deleteCategory}
+          onSetCategory={presetStore.actions.setCategory}
+          onMovePresetsToCategory={presetStore.actions.movePresetsToCategory}
+          onSetFavorite={presetStore.actions.setFavorite}
+          onSetFavorites={presetStore.actions.setFavorites}
+          onDuplicatePresets={presetStore.actions.duplicatePresets}
+          onDeletePresets={presetStore.actions.deletePresets}
         />
         <StereoModeToggle stereoEnabled={stereoEnabled} onToggle={onStereoToggle} />
         <IconButton

--- a/ui/src/components/PresetBar.tsx
+++ b/ui/src/components/PresetBar.tsx
@@ -783,18 +783,30 @@ export const PresetBar: React.FC<PresetBarProps> = ({
     [allUserPresets]
   );
 
-  // Root user presets (no category assigned)
-  const rootUserPresets = useMemo(
-    () => nonFavouriteUserPresets.filter((p) => !p.category || p.category.trim() === ''),
-    [nonFavouriteUserPresets]
-  );
-
   // Sorted user categories
   const sortedCategories = useMemo(() => {
     const cats = [...categories];
     cats.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
     return cats;
   }, [categories]);
+
+  // Set of known categories for fast case-insensitive lookup
+  const knownCategoriesSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const cat of sortedCategories) {
+      set.add(cat.toLowerCase());
+    }
+    return set;
+  }, [sortedCategories]);
+
+  // Root user presets (no category assigned, or assigned to unknown category)
+  const rootUserPresets = useMemo(
+    () =>
+      nonFavouriteUserPresets.filter(
+        (p) => !p.category || !p.category.trim() || !knownCategoriesSet.has(p.category.trim().toLowerCase())
+      ),
+    [nonFavouriteUserPresets, knownCategoriesSet]
+  );
 
   // Map category to its non-favourite presets
   const presetsByCategory = useMemo(() => {
@@ -932,22 +944,28 @@ export const PresetBar: React.FC<PresetBarProps> = ({
       // CASE E: Dropped onto another preset row
       if (targetPreset && sourcePreset) {
         if (reordering) {
-          const from = presets.findIndex((p) => p.id === sourceId);
-          const to = presets.findIndex((p) => p.id === targetPreset.id);
-          if (from !== -1 && to !== -1 && from !== to) {
+          // Reordering is strictly within the same section (user vs factory)
+          if (sourcePreset.factory !== targetPreset.factory) return;
+
+          const currentList = ordered ?? presets;
+          const section = currentList.filter((p) => p.factory === sourcePreset.factory);
+          const sectionFrom = section.findIndex((p) => p.id === sourceId);
+          const sectionTo = section.findIndex((p) => p.id === targetPreset.id);
+
+          if (sectionFrom !== -1 && sectionTo !== -1 && sectionFrom !== sectionTo) {
             setOrdered((prev) => {
               const list = prev ?? presets;
               const item = list.find((p) => p.id === sourceId);
               if (!item) return prev;
-              const section = list.filter((p) => p.factory === item.factory);
+              const sec = list.filter((p) => p.factory === item.factory);
               const others = list.filter((p) => p.factory !== item.factory);
-              const sectionFrom = section.findIndex((p) => p.id === sourceId);
-              const sectionTo = section.findIndex((p) => p.id === targetPreset.id);
-              if (sectionFrom === -1 || sectionTo === -1) return prev;
-              const moved = arrayMove(section, sectionFrom, sectionTo);
+              const sFrom = sec.findIndex((p) => p.id === sourceId);
+              const sTo = sec.findIndex((p) => p.id === targetPreset.id);
+              if (sFrom === -1 || sTo === -1) return prev;
+              const moved = arrayMove(sec, sFrom, sTo);
               return item.factory ? [...others, ...moved] : [...moved, ...others];
             });
-            onMove(sourceId, to - from);
+            onMove(sourceId, sectionTo - sectionFrom);
           }
           return;
         }
@@ -965,7 +983,7 @@ export const PresetBar: React.FC<PresetBarProps> = ({
         }
       }
     },
-    [presets, selectedIds, reordering, onMove, onMovePresetsToCategory, onSetFavorite, onSetFavorites, toast]
+    [presets, ordered, selectedIds, reordering, onMove, onMovePresetsToCategory, onSetFavorite, onSetFavorites, toast]
   );
 
   const renderRow = (preset: PresetInfo) => {

--- a/ui/src/components/PresetBar.tsx
+++ b/ui/src/components/PresetBar.tsx
@@ -2,43 +2,41 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowUpDown,
   Check,
+  CheckSquare,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
+  Copy,
+  Folder,
+  FolderPlus,
   GripVertical,
   MidiPort,
   Pencil,
   Plus,
   Save,
   Search,
+  Square,
+  Star,
   Trash2,
+  X,
 } from './icons';
 import { IconButton } from './IconButton';
-import { DragDropProvider } from '@dnd-kit/react';
-import { isSortable, useSortable } from '@dnd-kit/react/sortable';
+import { DragDropProvider, useDraggable, useDroppable } from '@dnd-kit/react';
+import { PointerActivationConstraints, PointerSensor } from '@dnd-kit/dom';
+import type { Sensors } from '@dnd-kit/dom';
 import { arrayMove } from '@dnd-kit/helpers';
 import type { DragEndEvent } from '@dnd-kit/react';
 import type { ActivePreset, PresetInfo } from '../types/chain';
 import { useDismissable } from '../hooks/useDismissable';
 import { useToast } from './Toast';
 import { HELP, helpProps } from './helpText';
-import { BORDER, FONT_MONO, GRAY, SEGMENTED_TRACK } from './theme';
+import { BRAND_YELLOW, BORDER, FONT_MONO, GRAY, SEGMENTED_TRACK } from './theme';
 import { setPresetPcNumbersEnabled, usePresetPcNumbersEnabled } from './uiPreferences';
-
-/**
- * Top-bar preset controls: ‹ name › pill, save and New buttons, with two
- * anchored panels: the save popover (name + save) and the preset browser
- * (search, user section with inline rename/delete, TONE3000 factory section,
- * and a reorder mode that swaps the row actions for a grip and drag-and-drop).
- *
- * Pure view: the list and all mutations come from usePresets, the active
- * preset rides the chain state poll. Prev/next walk the list in its shown
- * order (user section first, then factory, same as the native list), which
- * is also what MIDI program-change numbers follow. A MIDI-port toggle reveals
- * each row's PC number (persisted in localStorage); off by default.
- */
+import { getUiScale } from '../hooks/useUiScale';
 
 const MUTED = GRAY;
 const PANEL_BG = '#141416';
+const MAX_CATEGORY_LENGTH = 50;
 
 const panelStyle: React.CSSProperties = {
   position: 'absolute',
@@ -60,7 +58,6 @@ const inputStyle: React.CSSProperties = {
   borderRadius: '10rem',
   color: '#ffffff',
   fontSize: '13rem',
-  // Typed text and placeholders are body text: reset the global 600 default.
   fontWeight: 400,
   padding: '9rem 12rem',
   outline: 'none',
@@ -71,6 +68,9 @@ const sectionHeaderStyle: React.CSSProperties = {
   fontSize: '14rem',
   fontWeight: 700,
   padding: '8rem 4rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
 };
 
 const iconButtonStyle: React.CSSProperties = {
@@ -85,14 +85,215 @@ const iconButtonStyle: React.CSSProperties = {
   padding: '5rem',
 };
 
-type PresetGroup = 'factory' | 'user';
+interface ConfirmModalProps {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  confirmDestructive?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+const ConfirmModal: React.FC<ConfirmModalProps> = ({
+  title,
+  message,
+  confirmLabel = 'Delete',
+  confirmDestructive = true,
+  onConfirm,
+  onCancel,
+}) => (
+  <div
+    style={{
+      position: 'absolute',
+      inset: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.75)',
+      backdropFilter: 'blur(4rem)',
+      WebkitBackdropFilter: 'blur(4rem)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: '16rem',
+      zIndex: 600,
+      boxSizing: 'border-box',
+    }}
+  >
+    <div
+      style={{
+        backgroundColor: '#1C1C1E',
+        border: BORDER,
+        borderRadius: '12rem',
+        padding: '16rem',
+        width: '100%',
+        maxWidth: '300rem',
+        boxSizing: 'border-box',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12rem',
+      }}
+    >
+      <div style={{ color: '#ffffff', fontSize: '14rem', fontWeight: 600 }}>{title}</div>
+      <div
+        style={{
+          color: MUTED,
+          fontSize: '12rem',
+          fontWeight: 400,
+          lineHeight: 1.4,
+        }}
+      >
+        {message}
+      </div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '8rem', marginTop: '4rem' }}>
+        <button
+          onClick={onCancel}
+          style={{
+            background: 'transparent',
+            border: BORDER,
+            borderRadius: '6rem',
+            color: '#ffffff',
+            padding: '6rem 12rem',
+            fontSize: '12rem',
+            cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={onConfirm}
+          style={{
+            background: confirmDestructive ? '#d32f2f' : '#2563eb',
+            border: 'none',
+            borderRadius: '6rem',
+            color: '#ffffff',
+            padding: '6rem 12rem',
+            fontSize: '12rem',
+            fontWeight: 600,
+            cursor: 'pointer',
+          }}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+interface DroppableCategoryHeaderProps {
+  id: string;
+  categoryName: string;
+  count: number;
+  isCollapsed?: boolean;
+  onToggleCollapse?: () => void;
+  onDeleteCategory?: () => void;
+  canDelete?: boolean;
+  icon?: React.ReactNode;
+}
+
+const DroppableCategoryHeader: React.FC<DroppableCategoryHeaderProps> = ({
+  id,
+  categoryName,
+  count,
+  isCollapsed = false,
+  onToggleCollapse,
+  onDeleteCategory,
+  canDelete = true,
+  icon,
+}) => {
+  const { ref, isDropTarget } = useDroppable({
+    id: `cat-drop:${id}`,
+    type: 'category-target',
+    accept: ['user'],
+  });
+
+  return (
+    <div
+      ref={ref}
+      onClick={onToggleCollapse}
+      {...(onToggleCollapse ? helpProps(HELP.categoryToggle) : {})}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '6rem 4rem',
+        marginTop: '6rem',
+        borderRadius: '6rem',
+        backgroundColor: isDropTarget ? 'rgba(255, 255, 255, 0.16)' : 'transparent',
+        border: isDropTarget ? '1px dashed rgba(255, 255, 255, 0.45)' : '1px solid transparent',
+        transition: 'background-color 0.15s ease, border-color 0.15s ease',
+        cursor: onToggleCollapse ? 'pointer' : 'default',
+        userSelect: 'none',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: '6rem' }}>
+        {onToggleCollapse && (
+          isCollapsed ? (
+            <ChevronRight size={13} color={MUTED} style={{ flexShrink: 0 }} />
+          ) : (
+            <ChevronDown size={13} color={MUTED} style={{ flexShrink: 0 }} />
+          )
+        )}
+        {icon ?? <Folder size={13} color={MUTED} style={{ flexShrink: 0 }} />}
+        <span style={{ color: '#ffffff', fontSize: '13rem', fontWeight: 600 }}>{categoryName}</span>
+        <span style={{ color: MUTED, fontSize: '11rem', fontWeight: 400 }}>({count})</span>
+      </div>
+      {canDelete && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteCategory?.();
+          }}
+          {...helpProps(HELP.categoryDelete)}
+          aria-label={`Delete category ${categoryName}`}
+          style={{ ...iconButtonStyle, padding: '3rem', color: MUTED }}
+        >
+          <Trash2 size={12} />
+        </button>
+      )}
+    </div>
+  );
+};
+
+interface EmptyCategoryDropZoneProps {
+  category: string;
+  label?: string;
+}
+
+const EmptyCategoryDropZone: React.FC<EmptyCategoryDropZoneProps> = ({
+  category,
+  label = 'Empty category (drag presets here)',
+}) => {
+  const { ref, isDropTarget } = useDroppable({
+    id: `cat-empty-drop:${category}`,
+    type: 'category-target',
+    accept: ['user'],
+  });
+
+  return (
+    <div
+      ref={ref}
+      style={{
+        color: isDropTarget ? '#ffffff' : MUTED,
+        fontSize: '11rem',
+        fontStyle: 'italic',
+        padding: '8rem 24rem',
+        margin: '2rem 4rem',
+        borderRadius: '6rem',
+        backgroundColor: isDropTarget ? 'rgba(255, 255, 255, 0.14)' : 'rgba(255, 255, 255, 0.02)',
+        border: isDropTarget ? '1px dashed rgba(255, 255, 255, 0.5)' : '1px dashed rgba(255, 255, 255, 0.08)',
+        transition: 'all 0.15s ease',
+      }}
+    >
+      {label}
+    </div>
+  );
+};
 
 interface PresetRowProps {
   preset: PresetInfo;
-  index: number;
-  group: PresetGroup;
-  sortable: boolean;
-  /** MIDI program change that loads this preset; undefined past PC 127. */
+  draggable: boolean;
+  droppable?: boolean;
+  selectable: boolean;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
   pcNumber: number | undefined;
   isActive: boolean;
   isRenaming: boolean;
@@ -103,13 +304,16 @@ interface PresetRowProps {
   onLoad: () => void;
   onStartRename: () => void;
   onDelete: () => void;
+  onToggleFavorite: () => void;
 }
 
 const PresetRow: React.FC<PresetRowProps> = ({
   preset,
-  index,
-  group,
-  sortable,
+  draggable,
+  droppable = true,
+  selectable,
+  selected,
+  onToggleSelect,
   pcNumber,
   isActive,
   isRenaming,
@@ -120,33 +324,87 @@ const PresetRow: React.FC<PresetRowProps> = ({
   onLoad,
   onStartRename,
   onDelete,
+  onToggleFavorite,
 }) => {
-  const { ref, handleRef, isDragging } = useSortable({
+  const { ref: dragRef, handleRef, isDragging } = useDraggable({
     id: preset.id,
-    index,
-    group,
-    // Rows only accept drops from their own section, so a user preset can
-    // never be dragged into the factory list or vice versa.
-    type: group,
-    accept: group,
-    disabled: !sortable,
+    type: 'user',
+    disabled: !draggable,
   });
+
+  const { ref: dropRef, isDropTarget } = useDroppable({
+    id: `preset-drop:${preset.id}`,
+    type: 'category-target',
+    accept: ['user'],
+    disabled: !droppable,
+  });
+
+  const setRefs = useCallback(
+    (el: HTMLDivElement | null) => {
+      dragRef(el);
+      dropRef(el);
+    },
+    [dragRef, dropRef]
+  );
 
   return (
     <div
-      ref={ref}
+      ref={setRefs}
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: '8rem',
+        gap: '6rem',
         height: '32rem',
         padding: '0 4rem',
-        opacity: isDragging ? 0.75 : 1,
+        opacity: isDragging ? 0.45 : 1,
+        borderRadius: '6rem',
+        backgroundColor: isDropTarget
+          ? 'rgba(255, 255, 255, 0.16)'
+          : selected
+          ? 'rgba(255, 255, 255, 0.08)'
+          : 'transparent',
+        border: isDropTarget ? '1px dashed rgba(255, 255, 255, 0.45)' : '1px solid transparent',
+        transition: 'background-color 0.15s ease, border-color 0.15s ease',
       }}
     >
-      <span style={{ width: '16rem', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
-        {isActive && <Check size={14} color="#ffffff" />}
-      </span>
+      {/* Select checkbox OR active indicator */}
+      {selectable ? (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleSelect(preset.id);
+          }}
+          style={{ ...iconButtonStyle, padding: '2rem', flexShrink: 0 }}
+          aria-label={selected ? 'Deselect preset' : 'Select preset'}
+          {...helpProps(selected ? HELP.presetDeselect : HELP.presetSelect)}
+        >
+          {selected ? <CheckSquare size={14} color="#ffffff" /> : <Square size={14} color={MUTED} />}
+        </button>
+      ) : (
+        <span style={{ width: '16rem', flexShrink: 0, display: 'flex', alignItems: 'center' }}>
+          {isActive && <Check size={14} color="#ffffff" />}
+        </span>
+      )}
+
+      {/* Star / Favourite toggle */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggleFavorite();
+        }}
+        aria-label={preset.favorite ? 'Unstar preset' : 'Star preset'}
+        {...helpProps(preset.favorite ? HELP.presetUnfavorite : HELP.presetFavorite)}
+        style={{
+          ...iconButtonStyle,
+          padding: '2rem',
+          flexShrink: 0,
+          color: preset.favorite ? BRAND_YELLOW : 'rgba(255, 255, 255, 0.25)',
+        }}
+      >
+        <Star size={13} fill={preset.favorite ? BRAND_YELLOW : 'transparent'} />
+      </button>
+
+      {/* Name / Inline Rename */}
       {isRenaming ? (
         <input
           autoFocus
@@ -161,9 +419,13 @@ const PresetRow: React.FC<PresetRowProps> = ({
         />
       ) : (
         <button
-          onClick={onLoad}
+          onClick={() => {
+            if (selectable) onToggleSelect(preset.id);
+            else onLoad();
+          }}
           style={{
             flex: 1,
+            minWidth: 0,
             background: 'transparent',
             border: 'none',
             textAlign: 'left',
@@ -180,6 +442,8 @@ const PresetRow: React.FC<PresetRowProps> = ({
           {preset.name}
         </button>
       )}
+
+      {/* PC Number */}
       {pcNumber !== undefined && (
         <span
           {...helpProps(HELP.presetPc)}
@@ -194,43 +458,55 @@ const PresetRow: React.FC<PresetRowProps> = ({
           PC {pcNumber}
         </span>
       )}
-      {sortable ? (
-        <button
-          ref={handleRef}
-          type="button"
-          aria-label="Reorder"
-          {...helpProps(HELP.presetDrag)}
-          style={{
-            ...iconButtonStyle,
-            padding: '3rem',
-            flexShrink: 0,
-            cursor: isDragging ? 'grabbing' : 'grab',
-            // Keep the list from claiming the gesture on touch.
-            touchAction: 'none',
-          }}
-        >
-          <GripVertical size={14} />
-        </button>
-      ) : (
-        !preset.factory &&
-        !isRenaming && (
-          <>
+
+      {/* Action buttons and/or Drag handle */}
+      {!preset.factory && !isRenaming && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '2rem', flexShrink: 0 }}>
+          {!selectable && (
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onStartRename();
+                }}
+                {...helpProps(HELP.presetRename)}
+                aria-label="Rename preset"
+                style={{ ...iconButtonStyle, padding: '3rem', color: MUTED }}
+              >
+                <Pencil size={13} />
+              </button>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                {...helpProps(HELP.presetDelete)}
+                aria-label="Delete preset"
+                style={{ ...iconButtonStyle, padding: '3rem', color: MUTED }}
+              >
+                <Trash2 size={13} />
+              </button>
+            </>
+          )}
+          {draggable && (
             <button
-              onClick={onStartRename}
-              {...helpProps(HELP.presetRename)}
-              style={{ ...iconButtonStyle, padding: '3rem' }}
+              ref={handleRef}
+              type="button"
+              aria-label="Drag preset"
+              {...helpProps(HELP.presetDrag)}
+              style={{
+                ...iconButtonStyle,
+                padding: '3rem',
+                flexShrink: 0,
+                cursor: isDragging ? 'grabbing' : 'grab',
+                touchAction: 'none',
+                color: isDragging ? '#ffffff' : MUTED,
+              }}
             >
-              <Pencil size={13} />
+              <GripVertical size={14} />
             </button>
-            <button
-              onClick={onDelete}
-              {...helpProps(HELP.presetDelete)}
-              style={{ ...iconButtonStyle, padding: '3rem' }}
-            >
-              <Trash2 size={13} />
-            </button>
-          </>
-        )
+          )}
+        </div>
       )}
     </div>
   );
@@ -239,16 +515,22 @@ const PresetRow: React.FC<PresetRowProps> = ({
 interface PresetBarProps {
   active: ActivePreset | null;
   presets: PresetInfo[];
-  /** Greys out the New button: nothing differs from a fresh instance. */
+  categories?: string[];
   atDefault: boolean;
   onSave: (name: string) => Promise<{ id: string; name: string } | null>;
   onLoad: (id: string) => void;
   onRename: (id: string, name: string) => void;
   onDelete: (id: string) => void;
-  /** N steps within the preset's section (negative = earlier). */
   onMove: (id: string, delta: number) => void;
-  /** Clear the chain and reset every control to its default. */
   onReset: () => void;
+  onAddCategory?: (name: string) => Promise<boolean | null>;
+  onDeleteCategory?: (name: string) => Promise<boolean | null>;
+  onSetCategory?: (id: string, category: string) => Promise<boolean | null>;
+  onMovePresetsToCategory?: (ids: string[], category: string) => Promise<boolean | null>;
+  onSetFavorite?: (id: string, isFavorite: boolean) => Promise<boolean | null>;
+  onSetFavorites?: (ids: string[], isFavorite: boolean) => Promise<boolean | null>;
+  onDuplicatePresets?: (ids: string[]) => Promise<PresetInfo[] | null>;
+  onDeletePresets?: (ids: string[]) => Promise<boolean | null>;
 }
 
 type OpenPanel = 'none' | 'save' | 'browse';
@@ -256,6 +538,7 @@ type OpenPanel = 'none' | 'save' | 'browse';
 export const PresetBar: React.FC<PresetBarProps> = ({
   active,
   presets,
+  categories = [],
   atDefault,
   onSave,
   onLoad,
@@ -263,22 +546,76 @@ export const PresetBar: React.FC<PresetBarProps> = ({
   onDelete,
   onMove,
   onReset,
+  onAddCategory,
+  onDeleteCategory,
+  onMovePresetsToCategory,
+  onSetFavorite,
+  onSetFavorites,
+  onDuplicatePresets,
+  onDeletePresets,
 }) => {
   const [open, setOpen] = useState<OpenPanel>('none');
   const [saveName, setSaveName] = useState('');
   const [search, setSearch] = useState('');
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState('');
-  // Reorder mode: rows swap rename/delete for a grip handle. Drag only
-  // makes sense on the full list, so grips hide while a search filter is on.
+
+  // Mode toggles
   const [reordering, setReordering] = useState(false);
+  const [multiSelect, setMultiSelect] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+
+  // Category creation & deletion state
+  const [isCreatingCategory, setIsCreatingCategory] = useState(false);
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [categoryToDelete, setCategoryToDelete] = useState<string | null>(null);
+
+  // Bulk delete confirmation modal state
+  const [isConfirmingBulkDelete, setIsConfirmingBulkDelete] = useState(false);
+
+  // Move-to popover menu
+  const [isMoveMenuOpen, setIsMoveMenuOpen] = useState(false);
+
+  // Collapsed categories state (keys: '__favourites', '__uncategorized', or user category names)
+  const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
+
+  const toggleCollapseCategory = useCallback((catKey: string) => {
+    setCollapsedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(catKey)) next.delete(catKey);
+      else next.add(catKey);
+      return next;
+    });
+  }, []);
+
+  const sensors: Sensors = useMemo(
+    () => [
+      PointerSensor.configure({
+        activationConstraints: () => [
+          new PointerActivationConstraints.Distance({
+            value: 4 * getUiScale(),
+          }),
+        ],
+      }),
+    ],
+    []
+  );
+
   const showPcNumbers = usePresetPcNumbersEnabled();
   const toast = useToast();
   const containerRef = useRef<HTMLDivElement | null>(null);
-  const closePanels = useCallback(() => setOpen('none'), []);
+  const closePanels = useCallback(() => {
+    setOpen('none');
+    setMultiSelect(false);
+    setSelectedIds(new Set());
+    setIsCreatingCategory(false);
+    setCategoryToDelete(null);
+    setIsConfirmingBulkDelete(false);
+    setIsMoveMenuOpen(false);
+  }, []);
   useDismissable(open !== 'none', containerRef, closePanels);
 
-  // Optimistic order while a drag is in flight / until native list refresh.
+  // Optimistic order while a drag is in flight
   const [ordered, setOrdered] = useState<PresetInfo[] | null>(null);
   const draggingRef = useRef(false);
   useEffect(() => {
@@ -286,8 +623,6 @@ export const PresetBar: React.FC<PresetBarProps> = ({
   }, [presets]);
 
   const openSave = useCallback(() => {
-    // Prefill with the active user preset's name: saving it again is the
-    // one-click "update" path (same name overwrites in place).
     const activeInfo = active ? presets.find((p) => p.id === active.id) : undefined;
     setSaveName(activeInfo && !activeInfo.factory ? activeInfo.name : '');
     setOpen((prev) => (prev === 'save' ? 'none' : 'save'));
@@ -297,6 +632,12 @@ export const PresetBar: React.FC<PresetBarProps> = ({
     setSearch('');
     setRenamingId(null);
     setReordering(false);
+    setMultiSelect(false);
+    setSelectedIds(new Set());
+    setIsCreatingCategory(false);
+    setCategoryToDelete(null);
+    setIsConfirmingBulkDelete(false);
+    setIsMoveMenuOpen(false);
     setOrdered(null);
     setOpen((prev) => (prev === 'browse' ? 'none' : 'browse'));
   }, []);
@@ -309,9 +650,6 @@ export const PresetBar: React.FC<PresetBarProps> = ({
     if (saved) toast.show('Preset Saved');
   }, [saveName, onSave, toast]);
 
-  // Close the browser whenever a preset is chosen (list click or ‹ ›), then
-  // load. Prev/next wrap at the ends; with no active preset, › starts at the
-  // first and ‹ at the last.
   const loadAndClose = useCallback(
     (id: string) => {
       setOpen('none');
@@ -340,17 +678,139 @@ export const PresetBar: React.FC<PresetBarProps> = ({
     setRenamingId(null);
   }, [renamingId, renameValue, onRename]);
 
+  // Category creation
+  const handleCreateCategory = useCallback(async () => {
+    const trimmed = newCategoryName.trim();
+    if (!trimmed) {
+      setIsCreatingCategory(false);
+      return;
+    }
+    if (trimmed.length > MAX_CATEGORY_LENGTH) {
+      toast.show(`Category name must be ${MAX_CATEGORY_LENGTH} characters or less`);
+      return;
+    }
+    const exists = categories.some((c) => c.localeCompare(trimmed, undefined, { sensitivity: 'base' }) === 0);
+    if (exists) {
+      toast.show(`Category "${trimmed}" already exists`);
+      return;
+    }
+    const ok = await onAddCategory?.(trimmed);
+    if (ok) {
+      toast.show(`Category "${trimmed}" created`);
+      setNewCategoryName('');
+      setIsCreatingCategory(false);
+    }
+  }, [newCategoryName, categories, onAddCategory, toast]);
+
+  // Category deletion
+  const handleConfirmDeleteCategory = useCallback(async () => {
+    if (!categoryToDelete) return;
+    const cat = categoryToDelete;
+    setCategoryToDelete(null);
+    const ok = await onDeleteCategory?.(cat);
+    if (ok) toast.show(`Category "${cat}" deleted`);
+  }, [categoryToDelete, onDeleteCategory, toast]);
+
+  // Multi-select actions
+  const toggleSelectPreset = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const handleDuplicateSelected = useCallback(async () => {
+    if (selectedIds.size === 0) return;
+    const ids = Array.from(selectedIds);
+    const dupes = await onDuplicatePresets?.(ids);
+    if (dupes && dupes.length > 0) {
+      toast.show(dupes.length === 1 ? 'Preset duplicated' : `Duplicated ${dupes.length} presets`);
+      setSelectedIds(new Set());
+    }
+  }, [selectedIds, onDuplicatePresets, toast]);
+
+  const handleConfirmBulkDelete = useCallback(async () => {
+    setIsConfirmingBulkDelete(false);
+    if (selectedIds.size === 0) return;
+    const ids = Array.from(selectedIds);
+    const ok = await onDeletePresets?.(ids);
+    if (ok) {
+      toast.show(ids.length === 1 ? 'Preset deleted' : `Deleted ${ids.length} presets`);
+      setSelectedIds(new Set());
+    }
+  }, [selectedIds, onDeletePresets, toast]);
+
+  const handleMoveSelectedTo = useCallback(
+    async (targetCategory: string) => {
+      setIsMoveMenuOpen(false);
+      if (selectedIds.size === 0) return;
+      const ids = Array.from(selectedIds);
+      const ok = await onMovePresetsToCategory?.(ids, targetCategory);
+      if (ok) {
+        const dest = targetCategory || 'Your Presets';
+        toast.show(
+          ids.length === 1
+            ? `Moved to ${dest}`
+            : `Moved ${ids.length} presets to ${dest}`
+        );
+        setSelectedIds(new Set());
+      }
+    },
+    [selectedIds, onMovePresetsToCategory, toast]
+  );
+
+  // Filtered preset list
   const filtered = useMemo(() => {
     const list = ordered ?? presets;
     const q = search.trim().toLowerCase();
     return q ? list.filter((p) => p.name.toLowerCase().includes(q)) : list;
   }, [ordered, presets, search]);
-  const factoryPresets = filtered.filter((p) => p.factory);
-  const userPresets = filtered.filter((p) => !p.factory);
 
-  // PC n loads the nth preset of the full list (display order matches the
-  // native list), so the label is the index; built from the optimistic order
-  // so numbers track live while dragging. The wire only carries 0-127.
+  const factoryPresets = useMemo(() => filtered.filter((p) => p.factory), [filtered]);
+  const allUserPresets = useMemo(() => filtered.filter((p) => !p.factory), [filtered]);
+
+  // Favourites pinned group (any starred presets)
+  const favouritePresets = useMemo(
+    () => filtered.filter((p) => p.favorite),
+    [filtered]
+  );
+
+  // Non-favourited user presets (sit in their respective categories or root)
+  const nonFavouriteUserPresets = useMemo(
+    () => allUserPresets.filter((p) => !p.favorite),
+    [allUserPresets]
+  );
+
+  // Root user presets (no category assigned)
+  const rootUserPresets = useMemo(
+    () => nonFavouriteUserPresets.filter((p) => !p.category || p.category.trim() === ''),
+    [nonFavouriteUserPresets]
+  );
+
+  // Sorted user categories
+  const sortedCategories = useMemo(() => {
+    const cats = [...categories];
+    cats.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    return cats;
+  }, [categories]);
+
+  // Map category to its non-favourite presets
+  const presetsByCategory = useMemo(() => {
+    const map = new Map<string, PresetInfo[]>();
+    for (const cat of sortedCategories) {
+      map.set(
+        cat,
+        nonFavouriteUserPresets.filter(
+          (p) => p.category && p.category.localeCompare(cat, undefined, { sensitivity: 'base' }) === 0
+        )
+      );
+    }
+    return map;
+  }, [sortedCategories, nonFavouriteUserPresets]);
+
+  // PC number mapping for full list
   const pcById = useMemo(() => {
     const map = new Map<string, number>();
     (ordered ?? presets).forEach((preset, i) => {
@@ -371,9 +831,7 @@ export const PresetBar: React.FC<PresetBarProps> = ({
     alignSelf: 'stretch',
   };
 
-  // Grips only on the full list: a search filter's indices don't match the
-  // persisted order, and moves never cross the factory/user boundary.
-  const canDrag = reordering && search.trim() === '';
+  const canDrag = search.trim() === '';
 
   const handleDragStart = useCallback(() => {
     draggingRef.current = true;
@@ -382,38 +840,146 @@ export const PresetBar: React.FC<PresetBarProps> = ({
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       draggingRef.current = false;
-      const { source } = event.operation;
-      if (event.canceled || !isSortable(source)) return;
-      if (source.group !== source.initialGroup) return;
-      const from = source.initialIndex;
-      const to = source.index;
-      if (from === to) return;
-      const id = String(source.id);
-      setOrdered((prev) => {
-        const list = prev ?? presets;
-        const item = list.find((p) => p.id === id);
-        if (!item) return prev;
-        const section = list.filter((p) => p.factory === item.factory);
-        const others = list.filter((p) => p.factory !== item.factory);
-        const moved = arrayMove(section, from, to);
-        // User section first, then factory: must match the native list order
-        // since the PC labels index straight into this array.
-        return item.factory ? [...others, ...moved] : [...moved, ...others];
-      });
-      onMove(id, to - from);
+      const { source, target } = event.operation;
+      if (event.canceled || !source || !target) return;
+
+      const sourceId = String(source.id);
+      const targetId = String(target.id);
+      const sourcePreset = presets.find((p) => p.id === sourceId);
+
+      const targetPresetId = targetId.startsWith('preset-drop:')
+        ? targetId.slice('preset-drop:'.length)
+        : targetId;
+      const targetPreset = presets.find((p) => p.id === targetPresetId);
+
+      const ids = selectedIds.has(sourceId) ? Array.from(selectedIds) : [sourceId];
+
+      const isFromFavorites = sourcePreset?.favorite === true;
+      const isTargetInFavorites =
+        targetId === 'cat-drop:__favourites' ||
+        targetId === 'cat-empty-drop:__favourites' ||
+        (targetPreset != null && targetPreset.favorite === true);
+
+      // CASE A: Dragged INTO Favourites (from outside Favourites)
+      if (isTargetInFavorites && !isFromFavorites) {
+        if (onSetFavorites) {
+          onSetFavorites(ids, true);
+        } else {
+          for (const id of ids) onSetFavorite?.(id, true);
+        }
+        setSelectedIds(new Set());
+        toast.show(ids.length > 1 ? `Starred & added ${ids.length} presets to Favourites` : 'Starred & added to Favourites');
+        return;
+      }
+
+      // CASE B: Dragged OUT OF Favourites (into uncategorized or a category)
+      if (isFromFavorites && !isTargetInFavorites) {
+        // Automatically remove the star
+        if (onSetFavorites) {
+          onSetFavorites(ids, false);
+        } else {
+          for (const id of ids) onSetFavorite?.(id, false);
+        }
+
+        // Determine destination category
+        let destCat = '';
+        if (targetId.startsWith('cat-drop:')) {
+          destCat = targetId.slice('cat-drop:'.length);
+        } else if (targetId.startsWith('cat-empty-drop:')) {
+          destCat = targetId.slice('cat-empty-drop:'.length);
+        } else if (targetPreset && !targetPreset.factory) {
+          destCat = targetPreset.category ?? '';
+        }
+
+        if (destCat !== undefined) {
+          onMovePresetsToCategory?.(ids, destCat);
+        }
+
+        setSelectedIds(new Set());
+        const destName = destCat || 'All Uncategorized';
+        toast.show(
+          ids.length > 1
+            ? `Unstarred & moved ${ids.length} presets to ${destName}`
+            : `Unstarred & moved to ${destName}`
+        );
+        return;
+      }
+
+      // CASE C: Standard move to a category drop header
+      if (targetId.startsWith('cat-drop:')) {
+        const destCat = targetId.slice('cat-drop:'.length);
+        if (destCat !== '__favourites') {
+          onMovePresetsToCategory?.(ids, destCat);
+          const dest = destCat || 'All Uncategorized';
+          toast.show(ids.length > 1 ? `Moved ${ids.length} presets to ${dest}` : `Moved to ${dest}`);
+          setSelectedIds(new Set());
+          return;
+        }
+      }
+
+      // CASE D: Standard move to an empty category drop zone
+      if (targetId.startsWith('cat-empty-drop:')) {
+        const destCat = targetId.slice('cat-empty-drop:'.length);
+        if (destCat !== '__favourites') {
+          onMovePresetsToCategory?.(ids, destCat);
+          const dest = destCat || 'All Uncategorized';
+          toast.show(ids.length > 1 ? `Moved ${ids.length} presets to ${dest}` : `Moved to ${dest}`);
+          setSelectedIds(new Set());
+          return;
+        }
+      }
+
+      // CASE E: Dropped onto another preset row
+      if (targetPreset && sourcePreset) {
+        if (reordering) {
+          const from = presets.findIndex((p) => p.id === sourceId);
+          const to = presets.findIndex((p) => p.id === targetPreset.id);
+          if (from !== -1 && to !== -1 && from !== to) {
+            setOrdered((prev) => {
+              const list = prev ?? presets;
+              const item = list.find((p) => p.id === sourceId);
+              if (!item) return prev;
+              const section = list.filter((p) => p.factory === item.factory);
+              const others = list.filter((p) => p.factory !== item.factory);
+              const sectionFrom = section.findIndex((p) => p.id === sourceId);
+              const sectionTo = section.findIndex((p) => p.id === targetPreset.id);
+              if (sectionFrom === -1 || sectionTo === -1) return prev;
+              const moved = arrayMove(section, sectionFrom, sectionTo);
+              return item.factory ? [...others, ...moved] : [...moved, ...others];
+            });
+            onMove(sourceId, to - from);
+          }
+          return;
+        }
+
+        if (!sourcePreset.factory && !targetPreset.factory) {
+          const sourceCat = sourcePreset.category ?? '';
+          const targetCat = targetPreset.category ?? '';
+          if (sourceCat.localeCompare(targetCat, undefined, { sensitivity: 'base' }) !== 0) {
+            onMovePresetsToCategory?.(ids, targetCat);
+            const dest = targetCat || 'All Uncategorized';
+            toast.show(ids.length > 1 ? `Moved ${ids.length} presets to ${dest}` : `Moved to ${dest}`);
+            setSelectedIds(new Set());
+            return;
+          }
+        }
+      }
     },
-    [presets, onMove]
+    [presets, selectedIds, reordering, onMove, onMovePresetsToCategory, onSetFavorite, onSetFavorites, toast]
   );
 
-  const renderRow = (preset: PresetInfo, sectionIndex: number, group: PresetGroup) => {
+  const renderRow = (preset: PresetInfo) => {
     const isRenaming = renamingId === preset.id;
+    const isDraggable = !preset.factory ? canDrag : reordering && canDrag;
     return (
       <PresetRow
         key={preset.id}
         preset={preset}
-        index={sectionIndex}
-        group={group}
-        sortable={canDrag}
+        draggable={isDraggable}
+        droppable={!preset.factory || reordering}
+        selectable={multiSelect && !preset.factory}
+        selected={selectedIds.has(preset.id)}
+        onToggleSelect={toggleSelectPreset}
         pcNumber={showPcNumbers ? pcById.get(preset.id) : undefined}
         isActive={active?.id === preset.id}
         isRenaming={isRenaming}
@@ -427,6 +993,7 @@ export const PresetBar: React.FC<PresetBarProps> = ({
           setRenameValue(preset.name);
         }}
         onDelete={() => onDelete(preset.id)}
+        onToggleFavorite={() => onSetFavorite?.(preset.id, !preset.favorite)}
       />
     );
   };
@@ -443,7 +1010,6 @@ export const PresetBar: React.FC<PresetBarProps> = ({
           alignItems: 'stretch',
           height: '36rem',
           borderRadius: '8rem',
-          // Same fill as the model select bar (SEGMENTED_TRACK).
           backgroundColor: SEGMENTED_TRACK,
           padding: '0 4rem',
           flexShrink: 0,
@@ -462,8 +1028,6 @@ export const PresetBar: React.FC<PresetBarProps> = ({
             fontSize: '14rem',
             fontWeight: 400,
             cursor: 'pointer',
-            // Constant width so the pill never resizes with the name; long
-            // names ellipsize. Full pill height is the click target.
             width: '150rem',
             height: '100%',
             lineHeight: '36rem',
@@ -481,12 +1045,12 @@ export const PresetBar: React.FC<PresetBarProps> = ({
         </button>
       </div>
 
-      {/* Save */}
+      {/* Save button */}
       <button onClick={openSave} {...helpProps(HELP.presetSave)} style={iconButtonStyle}>
         <Save size={18} />
       </button>
 
-      {/* New: back to the factory-default state, greyed once already there. */}
+      {/* New button: back to default */}
       <IconButton
         onClick={() => {
           setOpen('none');
@@ -537,17 +1101,17 @@ export const PresetBar: React.FC<PresetBarProps> = ({
         </div>
       )}
 
-      {/* Preset browser. Top/bottom spacing lives in the scroll content so
-          the list clips at the search row and the panel border. */}
+      {/* Preset Browser */}
       {open === 'browse' && (
         <div
           style={{
             ...panelStyle,
-            width: '360rem',
+            width: '380rem',
             padding: '12rem 12rem 0',
             overflow: 'hidden',
           }}
         >
+          {/* Top toolbar */}
           <div style={{ display: 'flex', alignItems: 'center', gap: '6rem' }}>
             <div style={{ position: 'relative', flex: 1, minWidth: 0 }}>
               <Search
@@ -568,6 +1132,8 @@ export const PresetBar: React.FC<PresetBarProps> = ({
                 style={{ ...inputStyle, padding: '8rem 12rem 8rem 32rem', borderRadius: '10rem' }}
               />
             </div>
+
+            {/* PC Numbers toggle */}
             {presets.length > 0 && (
               <button
                 onClick={() => setPresetPcNumbersEnabled(!showPcNumbers)}
@@ -584,7 +1150,9 @@ export const PresetBar: React.FC<PresetBarProps> = ({
                 <MidiPort size={15} />
               </button>
             )}
-            {presets.length > 1 && (
+
+            {/* Reorder toggle */}
+            {presets.length > 1 && !multiSelect && (
               <button
                 onClick={() => setReordering((prev) => !prev)}
                 aria-pressed={reordering}
@@ -600,23 +1168,355 @@ export const PresetBar: React.FC<PresetBarProps> = ({
                 <ArrowUpDown size={15} />
               </button>
             )}
+
+            {/* Multi-select toggle */}
+            {allUserPresets.length > 0 && !reordering && (
+              <button
+                onClick={() => {
+                  setMultiSelect((prev) => {
+                    if (prev) setSelectedIds(new Set());
+                    return !prev;
+                  });
+                }}
+                aria-pressed={multiSelect}
+                aria-label="Toggle bulk selection mode"
+                {...helpProps(HELP.presetMultiSelectToggle)}
+                style={{
+                  ...iconButtonStyle,
+                  padding: '7rem',
+                  flexShrink: 0,
+                  color: multiSelect ? '#ffffff' : MUTED,
+                  background: multiSelect ? 'rgba(255, 255, 255, 0.12)' : 'transparent',
+                }}
+              >
+                <CheckSquare size={15} />
+              </button>
+            )}
           </div>
 
-          <DragDropProvider onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-            <div className="hide-scrollbar" style={{ maxHeight: '362rem', overflowY: 'auto' }}>
+          {/* Bulk actions bar */}
+          {multiSelect && selectedIds.size > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '8rem 10rem',
+                marginTop: '8rem',
+                backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                borderRadius: '8rem',
+                border: BORDER,
+                position: 'relative',
+              }}
+            >
+              <span style={{ fontSize: '12rem', color: '#ffffff', fontWeight: 600 }}>
+                {selectedIds.size} selected
+              </span>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6rem' }}>
+                {/* Move to dropdown */}
+                <div style={{ position: 'relative' }}>
+                  <button
+                    onClick={() => setIsMoveMenuOpen((prev) => !prev)}
+                    {...helpProps(HELP.bulkMove)}
+                    style={{
+                      ...iconButtonStyle,
+                      padding: '4rem 8rem',
+                      borderRadius: '6rem',
+                      border: BORDER,
+                      fontSize: '11rem',
+                      gap: '4rem',
+                    }}
+                  >
+                    <Folder size={12} />
+                    Move to
+                  </button>
+                  {isMoveMenuOpen && (
+                    <div
+                      style={{
+                        position: 'absolute',
+                        top: 'calc(100% + 4rem)',
+                        right: 0,
+                        backgroundColor: '#1C1C1E',
+                        border: BORDER,
+                        borderRadius: '8rem',
+                        padding: '4rem',
+                        minWidth: '150rem',
+                        zIndex: 700,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        gap: '2rem',
+                        boxShadow: '0 8rem 16rem rgba(0,0,0,0.5)',
+                      }}
+                    >
+                      <button
+                        onClick={() => handleMoveSelectedTo('')}
+                        style={{
+                          background: 'transparent',
+                          border: 'none',
+                          color: '#ffffff',
+                          textAlign: 'left',
+                          fontSize: '12rem',
+                          padding: '6rem 8rem',
+                          borderRadius: '4rem',
+                          cursor: 'pointer',
+                        }}
+                      >
+                        Your Presets (root)
+                      </button>
+                      {sortedCategories.map((cat) => (
+                        <button
+                          key={cat}
+                          onClick={() => handleMoveSelectedTo(cat)}
+                          style={{
+                            background: 'transparent',
+                            border: 'none',
+                            color: '#ffffff',
+                            textAlign: 'left',
+                            fontSize: '12rem',
+                            padding: '6rem 8rem',
+                            borderRadius: '4rem',
+                            cursor: 'pointer',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                          }}
+                        >
+                          {cat}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+
+                {/* Duplicate selected */}
+                <button
+                  onClick={handleDuplicateSelected}
+                  aria-label="Duplicate selected presets"
+                  {...helpProps(HELP.bulkDuplicate)}
+                  style={{
+                    ...iconButtonStyle,
+                    padding: '4rem 8rem',
+                    borderRadius: '6rem',
+                    border: BORDER,
+                    fontSize: '11rem',
+                    gap: '4rem',
+                  }}
+                >
+                  <Copy size={12} />
+                  Duplicate
+                </button>
+
+                {/* Delete selected */}
+                <button
+                  onClick={() => setIsConfirmingBulkDelete(true)}
+                  aria-label="Delete selected presets"
+                  {...helpProps(HELP.bulkDelete)}
+                  style={{
+                    ...iconButtonStyle,
+                    padding: '4rem 8rem',
+                    borderRadius: '6rem',
+                    border: BORDER,
+                    fontSize: '11rem',
+                    color: '#ff6b6b',
+                    gap: '4rem',
+                  }}
+                >
+                  <Trash2 size={12} />
+                  Delete
+                </button>
+
+                {/* Deselect all */}
+                <button
+                  onClick={() => setSelectedIds(new Set())}
+                  aria-label="Deselect all"
+                  {...helpProps(HELP.presetDeselectAll)}
+                  style={{ ...iconButtonStyle, padding: '4rem' }}
+                >
+                  <X size={13} />
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Preset list content */}
+          <DragDropProvider sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+            <div className="preset-scrollbar" style={{ maxHeight: '380rem', overflowY: 'auto', paddingRight: '4rem' }}>
               <div style={{ padding: '10rem 0 12rem' }}>
-                {userPresets.length > 0 && (
+                {/* 1. Pinned Favourites Category */}
+                <div style={{ marginBottom: '10rem' }}>
+                  <DroppableCategoryHeader
+                    id="__favourites"
+                    categoryName="Favourites"
+                    count={favouritePresets.length}
+                    isCollapsed={collapsedCategories.has('__favourites')}
+                    onToggleCollapse={() => toggleCollapseCategory('__favourites')}
+                    canDelete={false}
+                    icon={<Star size={13} fill={BRAND_YELLOW} color={BRAND_YELLOW} style={{ flexShrink: 0 }} />}
+                  />
+                  {!collapsedCategories.has('__favourites') && (
+                    favouritePresets.length > 0 ? (
+                      favouritePresets.map((preset) => renderRow(preset))
+                    ) : (
+                      <EmptyCategoryDropZone
+                        category="__favourites"
+                        label="Empty favourites (drag presets here to star)"
+                      />
+                    )
+                  )}
+                </div>
+
+                {/* 2. Your Presets Section */}
+                {(allUserPresets.length > 0 || categories.length > 0) && (
                   <>
-                    <div style={sectionHeaderStyle}>Your Presets</div>
-                    {userPresets.map((preset, i) => renderRow(preset, i, 'user'))}
+                    <div style={sectionHeaderStyle}>
+                      <span>Your Presets</span>
+                      <button
+                        onClick={() => setIsCreatingCategory((prev) => !prev)}
+                        aria-label="Create category"
+                        {...helpProps(HELP.categoryCreate)}
+                        style={{
+                          ...iconButtonStyle,
+                          padding: '3rem',
+                          color: isCreatingCategory ? '#ffffff' : MUTED,
+                        }}
+                      >
+                        <FolderPlus size={15} />
+                      </button>
+                    </div>
+
+                    {/* Inline Create Category Input */}
+                    {isCreatingCategory && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: '6rem',
+                          padding: '6rem 4rem',
+                          marginBottom: '6rem',
+                        }}
+                      >
+                        <Folder size={14} color={MUTED} style={{ flexShrink: 0 }} />
+                        <input
+                          autoFocus
+                          value={newCategoryName}
+                          maxLength={MAX_CATEGORY_LENGTH}
+                          onChange={(e) => setNewCategoryName(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleCreateCategory();
+                            if (e.key === 'Escape') setIsCreatingCategory(false);
+                          }}
+                          placeholder="New category..."
+                          style={{
+                            ...inputStyle,
+                            padding: '4rem 8rem',
+                            borderRadius: '6rem',
+                            flex: 1,
+                            fontSize: '12rem',
+                          }}
+                        />
+                        <button
+                          onClick={handleCreateCategory}
+                          style={{ ...iconButtonStyle, padding: '3rem' }}
+                        >
+                          <Check size={14} />
+                        </button>
+                        <button
+                          onClick={() => {
+                            setIsCreatingCategory(false);
+                            setNewCategoryName('');
+                          }}
+                          style={{ ...iconButtonStyle, padding: '3rem' }}
+                        >
+                          <X size={14} />
+                        </button>
+                      </div>
+                    )}
+
+                    {/* Droppable Root Header (moves presets to root) */}
+                    <DroppableCategoryHeader
+                      id=""
+                      categoryName="All Uncategorized"
+                      count={rootUserPresets.length}
+                      isCollapsed={collapsedCategories.has('__uncategorized')}
+                      onToggleCollapse={() => toggleCollapseCategory('__uncategorized')}
+                      onDeleteCategory={() => {}}
+                      canDelete={false}
+                    />
+
+                    {/* Root Presets (non-favourited) */}
+                    {!collapsedCategories.has('__uncategorized') && (
+                      <>
+                        {rootUserPresets.map((preset) => renderRow(preset))}
+                        {rootUserPresets.length === 0 && categories.length > 0 && (
+                          <EmptyCategoryDropZone
+                            category=""
+                            label="No uncategorized presets (drag here to uncategorize)"
+                          />
+                        )}
+                      </>
+                    )}
+
+                    {/* User Categories */}
+                    {sortedCategories.map((category) => {
+                      const categoryPresets = presetsByCategory.get(category) ?? [];
+                      const isCollapsed = collapsedCategories.has(category);
+                      return (
+                        <div key={category} style={{ marginTop: '6rem' }}>
+                          <DroppableCategoryHeader
+                            id={category}
+                            categoryName={category}
+                            count={categoryPresets.length}
+                            isCollapsed={isCollapsed}
+                            onToggleCollapse={() => toggleCollapseCategory(category)}
+                            onDeleteCategory={() => setCategoryToDelete(category)}
+                            canDelete={true}
+                          />
+                          {!isCollapsed && (
+                            categoryPresets.length > 0 ? (
+                              categoryPresets.map((preset) => renderRow(preset))
+                            ) : (
+                              <EmptyCategoryDropZone category={category} />
+                            )
+                          )}
+                        </div>
+                      );
+                    })}
                   </>
                 )}
+
+                {/* 3. TONE3000 Factory Section */}
                 {factoryPresets.length > 0 && (
                   <>
-                    <div style={sectionHeaderStyle}>TONE3000</div>
-                    {factoryPresets.map((preset, i) => renderRow(preset, i, 'factory'))}
+                    <div
+                      onClick={() => toggleCollapseCategory('__factory')}
+                      {...helpProps(HELP.categoryToggle)}
+                      style={{
+                        ...sectionHeaderStyle,
+                        marginTop: '12rem',
+                        cursor: 'pointer',
+                        userSelect: 'none',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '6rem',
+                      }}
+                    >
+                      {collapsedCategories.has('__factory') ? (
+                        <ChevronRight size={13} color={MUTED} style={{ flexShrink: 0 }} />
+                      ) : (
+                        <ChevronDown size={13} color={MUTED} style={{ flexShrink: 0 }} />
+                      )}
+                      <span>TONE3000</span>
+                      <span style={{ color: MUTED, fontSize: '11rem', fontWeight: 400 }}>
+                        ({factoryPresets.length})
+                      </span>
+                    </div>
+                    {!collapsedCategories.has('__factory') &&
+                      factoryPresets.map((preset) => renderRow(preset))}
                   </>
                 )}
+
+                {/* Empty State */}
                 {filtered.length === 0 && (
                   <div
                     style={{
@@ -634,6 +1534,28 @@ export const PresetBar: React.FC<PresetBarProps> = ({
               </div>
             </div>
           </DragDropProvider>
+
+          {/* Confirm Delete Category Modal */}
+          {categoryToDelete && (
+            <ConfirmModal
+              title="Delete Category"
+              message={`Are you sure you want to delete "${categoryToDelete}"? Presets inside will be moved to Your Presets.`}
+              confirmLabel="Delete"
+              onConfirm={handleConfirmDeleteCategory}
+              onCancel={() => setCategoryToDelete(null)}
+            />
+          )}
+
+          {/* Confirm Bulk Delete Presets Modal */}
+          {isConfirmingBulkDelete && (
+            <ConfirmModal
+              title="Delete Presets"
+              message={`Are you sure you want to delete ${selectedIds.size} selected preset(s)? This cannot be undone.`}
+              confirmLabel="Delete"
+              onConfirm={handleConfirmBulkDelete}
+              onCancel={() => setIsConfirmingBulkDelete(false)}
+            />
+          )}
         </div>
       )}
     </div>

--- a/ui/src/components/helpText.ts
+++ b/ui/src/components/helpText.ts
@@ -197,10 +197,23 @@ export const HELP = {
   presetRename: 'Rename: edit name. Enter: commit · Esc: cancel.',
   presetDelete: 'Delete: remove this preset.',
   presetReorder: 'Reorder: drag presets into a custom order. Prev/Next and MIDI follow it.',
-  presetDrag: 'Drag: move this preset within its section.',
+  presetDrag: 'Drag: drag this preset into or out of a category, or reorder.',
   presetPcToggle:
     'MIDI PC: show each preset\u2019s program change number. Prev/Next and PC follow the list order.',
   presetPc: 'PC: the MIDI program change number that loads this preset.',
+  presetFavorite: 'Favorite: star this preset to pin it in Favourites.',
+  presetUnfavorite: 'Unfavorite: unstar this preset to remove it from Favourites.',
+  presetSelect: 'Select: choose this preset for bulk actions (move, duplicate, delete).',
+  presetDeselect: 'Deselect: remove this preset from selection.',
+  presetMultiSelectToggle: 'Bulk Actions: toggle multi-selection to move, duplicate, or delete presets in bulk.',
+  presetSelectAll: 'Select All: select all presets.',
+  presetDeselectAll: 'Deselect All: clear selection.',
+  bulkMove: 'Move Presets: move selected presets to another category.',
+  bulkDuplicate: 'Duplicate Presets: make copies of all selected presets.',
+  bulkDelete: 'Delete Presets: permanently delete all selected presets.',
+  categoryCreate: 'Create Category: add a new user preset category.',
+  categoryDelete: 'Delete Category: delete this category (presets return to Your Presets).',
+  categoryToggle: 'Category: click to collapse or expand this category.',
 
   // Chain gallery
   addTile:

--- a/ui/src/components/icons.tsx
+++ b/ui/src/components/icons.tsx
@@ -8,6 +8,7 @@ import {
   Bluetooth as LBluetooth,
   Bookmark as LBookmark,
   Check as LCheck,
+  CheckSquare as LCheckSquare,
   ChevronDown as LChevronDown,
   ChevronLeft as LChevronLeft,
   ChevronRight as LChevronRight,
@@ -19,7 +20,10 @@ import {
   Equal as LEqual,
   ExternalLink as LExternalLink,
   File as LFile,
+  Folder as LFolder,
   FolderClosed as LFolderClosed,
+  FolderPlus as LFolderPlus,
+  FolderX as LFolderX,
   Gauge as LGauge,
   GripVertical as LGripVertical,
   Info as LInfo,
@@ -39,6 +43,8 @@ import {
   Settings as LSettings,
   Share as LShare,
   ShieldAlert as LShieldAlert,
+  Square as LSquare,
+  Star as LStar,
   Trash2 as LTrash2,
   Undo2 as LUndo2,
   Upload as LUpload,
@@ -74,6 +80,7 @@ export const ArrowUpDown = scaled(LArrowUpDown, 'ArrowUpDown');
 export const Bluetooth = scaled(LBluetooth, 'Bluetooth');
 export const Bookmark = scaled(LBookmark, 'Bookmark');
 export const Check = scaled(LCheck, 'Check');
+export const CheckSquare = scaled(LCheckSquare, 'CheckSquare');
 export const ChevronDown = scaled(LChevronDown, 'ChevronDown');
 export const ChevronLeft = scaled(LChevronLeft, 'ChevronLeft');
 export const ChevronRight = scaled(LChevronRight, 'ChevronRight');
@@ -85,7 +92,10 @@ export const Download = scaled(LDownload, 'Download');
 export const Equal = scaled(LEqual, 'Equal');
 export const ExternalLink = scaled(LExternalLink, 'ExternalLink');
 export const File = scaled(LFile, 'File');
+export const Folder = scaled(LFolder, 'Folder');
 export const FolderClosed = scaled(LFolderClosed, 'FolderClosed');
+export const FolderPlus = scaled(LFolderPlus, 'FolderPlus');
+export const FolderX = scaled(LFolderX, 'FolderX');
 export const Gauge = scaled(LGauge, 'Gauge');
 export const GripVertical = scaled(LGripVertical, 'GripVertical');
 export const Info = scaled(LInfo, 'Info');
@@ -105,6 +115,8 @@ export const Search = scaled(LSearch, 'Search');
 export const Settings = scaled(LSettings, 'Settings');
 export const Share = scaled(LShare, 'Share');
 export const ShieldAlert = scaled(LShieldAlert, 'ShieldAlert');
+export const Square = scaled(LSquare, 'Square');
+export const Star = scaled(LStar, 'Star');
 export const Trash2 = scaled(LTrash2, 'Trash2');
 export const Undo2 = scaled(LUndo2, 'Undo2');
 export const Upload = scaled(LUpload, 'Upload');

--- a/ui/src/hooks/usePresets.ts
+++ b/ui/src/hooks/usePresets.ts
@@ -28,16 +28,29 @@ export function usePresets(onChanged?: () => void) {
       renamePreset: backend.getPluginFunction('renamePreset'),
       deletePreset: backend.getPluginFunction('deletePreset'),
       movePreset: backend.getPluginFunction('movePreset'),
+      addPresetCategory: backend.getPluginFunction('addPresetCategory'),
+      deletePresetCategory: backend.getPluginFunction('deletePresetCategory'),
+      setPresetCategory: backend.getPluginFunction('setPresetCategory'),
+      movePresetsToCategory: backend.getPluginFunction('movePresetsToCategory'),
+      setPresetFavorite: backend.getPluginFunction('setPresetFavorite'),
+      setPresetsFavorite: backend.getPluginFunction('setPresetsFavorite'),
+      duplicatePresets: backend.getPluginFunction('duplicatePresets'),
+      deletePresets: backend.getPluginFunction('deletePresets'),
     }),
     [backend]
   );
 
   const [presets, setPresets] = useState<PresetInfo[]>([]);
+  const [categories, setCategories] = useState<string[]>([]);
 
   const refreshList = useCallback(async () => {
     try {
-      const res = (await native.getPresetList()) as { presets?: PresetInfo[] } | null;
+      const res = (await native.getPresetList()) as {
+        presets?: PresetInfo[];
+        categories?: string[];
+      } | null;
       setPresets(res?.presets ?? []);
+      setCategories(res?.categories ?? []);
     } catch (error) {
       console.error('Error loading preset list:', error);
     }
@@ -78,9 +91,33 @@ export function usePresets(onChanged?: () => void) {
           persists and drives prev/next and MIDI program-change numbers. */
       move: (id: string, delta: number) =>
         run<boolean>('movePreset', () => native.movePreset(id, delta)),
+      /** Create a new user category. */
+      addCategory: (name: string) =>
+        run<boolean>('addPresetCategory', () => native.addPresetCategory(name)),
+      /** Delete a user category (presets inside move to root). */
+      deleteCategory: (name: string) =>
+        run<boolean>('deletePresetCategory', () => native.deletePresetCategory(name)),
+      /** Assign a preset to a category (or "" for root). */
+      setCategory: (id: string, category: string) =>
+        run<boolean>('setPresetCategory', () => native.setPresetCategory(id, category)),
+      /** Move multiple presets to a category (or "" for root). */
+      movePresetsToCategory: (ids: string[], category: string) =>
+        run<boolean>('movePresetsToCategory', () => native.movePresetsToCategory(ids, category)),
+      /** Toggle favourite / star status. */
+      setFavorite: (id: string, isFavorite: boolean) =>
+        run<boolean>('setPresetFavorite', () => native.setPresetFavorite(id, isFavorite)),
+      /** Set favourite / star status for multiple presets. */
+      setFavorites: (ids: string[], isFavorite: boolean) =>
+        run<boolean>('setPresetsFavorite', () => native.setPresetsFavorite(ids, isFavorite)),
+      /** Duplicate one or more presets (prepends "Copy-"). */
+      duplicatePresets: (ids: string[]) =>
+        run<PresetInfo[]>('duplicatePresets', () => native.duplicatePresets(ids)),
+      /** Delete multiple presets. */
+      deletePresets: (ids: string[]) =>
+        run<boolean>('deletePresets', () => native.deletePresets(ids)),
     }),
     [native, run]
   );
 
-  return { presets, refreshList, actions };
+  return { presets, categories, refreshList, actions };
 }

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -264,3 +264,26 @@ input[type='range'].accent-blue::-moz-range-thumb {
 .hide-scrollbar::-webkit-scrollbar {
   display: none; /* Chrome, Safari, Opera */
 }
+
+/* Styled scrollbar for preset list */
+.preset-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.25) transparent;
+}
+
+.preset-scrollbar::-webkit-scrollbar {
+  width: 6rem;
+}
+
+.preset-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.preset-scrollbar::-webkit-scrollbar-thumb {
+  background-color: rgba(255, 255, 255, 0.22);
+  border-radius: 4rem;
+}
+
+.preset-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: rgba(255, 255, 255, 0.45);
+}

--- a/ui/src/types/chain.ts
+++ b/ui/src/types/chain.ts
@@ -204,6 +204,10 @@ export interface PresetInfo {
   name: string;
   /** Bundled TONE3000 preset; read-only (no rename/delete). */
   factory: boolean;
+  /** User-defined category name, or undefined/empty for root "Your Presets". */
+  category?: string;
+  /** Starred / favourite status. */
+  favorite?: boolean;
 }
 
 /** The preset shown in the top-bar pill. */


### PR DESCRIPTION
## Summary

Improves preset organization and management in the preset drawer with user-defined categories, favourites, drag and drop, bulk editing, and list navigation:

- User categories: Create and delete custom categories in "Your Presets" with unicode / multilingual support and a 50-character limit. Deleting a category moves its presets back to root uncategorized without deleting them.
- Favourites: Star presets to pin them to a dedicated "Favourites" group at the top of the drawer.
- Drag and drop: Drag presets between categories, into or out of Favourites, onto individual presets, and into empty category drop zones using @dnd-kit draggable/droppable. Moving a preset into Favourites stars it; moving it out unstars it.
- Expand and collapse: Toggle accordion view for user categories, Favourites, and Uncategorized sections.
- Bulk actions: Multi-select mode with checkboxes to batch move to a category, batch duplicate (prefixing "Copy-"), batch star/unstar, or batch delete.
- Preset list scrollbar: Added a styled scrollbar so large preset collections can be scrolled comfortably.
- Info bar tooltips: Added hover descriptions in the bottom status bar for category toggle/create/delete, star toggles, and bulk operations.

### Demo

https://github.com/tlennon-ie/tone3000-plugin/releases/download/demo-assets/Sample.Video.mp4


https://github.com/user-attachments/assets/9a9a92aa-f80a-4d74-85e6-96dcdf4f2b5f



## Test plan

- [x] DSP: Ran unit tests via GoogleTest: `DspTests.exe --gtest_filter="PresetManagerTest.*"` (all 13 tests pass, including new category lifecycle, multilingual naming, assignment, move, deletion fallback, favorites persistence, and batch duplicate/delete tests).
- [x] UI: `cd ui && npm run lint && npm run build` (0 lint errors/warnings, production bundle builds cleanly).
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [x] Host smoke (DAW + format + sample rate), if this is user-visible: Verified in Standalone on Windows 11 at 48kHz (tested category creation/deletion, accordion folding, drag-and-drop between categories and Favourites, bulk selection, duplication, and deletion).

## Compatibility

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [x] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly (preset state schema remains backward compatible; categories and favorites are stored in companion JSON files alongside user presets).
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
