### PR TITLE
iOS: privacy manifest, opaque icons, export compliance and a bumpable build number

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -74,9 +74,11 @@ Simulator build.
 
 - `plugin/PrivacyInfo.xcprivacy` declares the required-reason APIs the binary
   reaches through JUCE: user defaults (the WebView component), file timestamps
-  and free disk space (both `juce_SharedCode_posix.h`). An upload whose binary
-  calls one of those without declaring it is rejected with ITMS-91053, so the
-  list is worth re-deriving whenever the JUCE version moves.
+  and free disk space (both `juce_SharedCode_posix.h`), and system boot time
+  (`systemUptime` timestamping touch events in
+  `juce_UIViewComponentPeer_ios.mm`, plus `mach_absolute_time`). An upload whose
+  binary calls one of those without declaring it is rejected with ITMS-91053,
+  so the list is worth re-deriving whenever the JUCE version moves.
 - The app icons are flattened to opaque at configure time with ImageMagick.
   juceaide writes them RGBA whatever the source is, and an alpha channel on the
   1024 icon means ITMS-90717 and no icon in TestFlight. Without ImageMagick the

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -8,9 +8,15 @@ Deployment target iOS 16. Landscape only.
 
 ## Build
 
-The UI is embedded as JUCE binary data, so it is built first.
+Configure first, then build the UI, then configure again. `ui/package.json`
+resolves `@juce-framework/webview` from `libs/juce`, which the first configure
+is what creates, so building the UI first on a clean checkout fails with
+`Cannot find module '@juce-framework/webview'`. That first configure embeds a
+placeholder UI; the second picks up the real bundle. Same order as the root
+README and the `iOS Simulator` CI job.
 
 ```sh
+cmake --preset ios-simulator   # or ios-device: bootstrap, fetches JUCE into libs/
 cd ui && npm ci && npm run build && cd ..
 
 # Simulator

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -87,6 +87,11 @@ Simulator build.
 - `plugin/icon/icon.png` is 512x512 and juceaide never enlarges a source, so the
   App Store icon is currently that 512 artwork centred on a blank 1024 field.
   Exporting the icon at 1024 fixes it; the configure step warns until then.
+- `T3K_IOS_BUILD_NUMBER` is CFBundleVersion, and it defaults to 1. App Store
+  Connect refuses a build number it has already seen for the same marketing
+  version, so a second upload of one version needs
+  `-DT3K_IOS_BUILD_NUMBER=<n>`. Without the setting at all, JUCE uses the
+  marketing version as the build number and the second upload always bounces.
 - App Store Connect requires uploads built against a current iOS SDK. A runner
   pinned to an older Xcode builds and signs fine and is then refused at upload,
   which reads as a signing problem and is not one.

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -66,6 +66,31 @@ prefer it to the command line.
 
 Simulator screenshots come out portrait while the app renders landscape.
 
+## TestFlight and the App Store
+
+A signed build is the `ios-device` preset plus your team. Everything below is
+what App Store Connect checks on top of that, and none of it shows up in a
+Simulator build.
+
+- `plugin/PrivacyInfo.xcprivacy` declares the required-reason APIs the binary
+  reaches through JUCE: user defaults (the WebView component), file timestamps
+  and free disk space (both `juce_SharedCode_posix.h`). An upload whose binary
+  calls one of those without declaring it is rejected with ITMS-91053, so the
+  list is worth re-deriving whenever the JUCE version moves.
+- The app icons are flattened to opaque at configure time with ImageMagick.
+  juceaide writes them RGBA whatever the source is, and an alpha channel on the
+  1024 icon means ITMS-90717 and no icon in TestFlight. Without ImageMagick the
+  configure step warns; Simulator builds are unaffected either way.
+- `ITSAppUsesNonExemptEncryption` is false in the Info.plist. The app's only
+  encryption is standard HTTPS, and declaring it here answers the
+  export-compliance question once instead of on every upload.
+- `plugin/icon/icon.png` is 512x512 and juceaide never enlarges a source, so the
+  App Store icon is currently that 512 artwork centred on a blank 1024 field.
+  Exporting the icon at 1024 fixes it; the configure step warns until then.
+- App Store Connect requires uploads built against a current iOS SDK. A runner
+  pinned to an older Xcode builds and signs fine and is then refused at upload,
+  which reads as a signing problem and is not one.
+
 ## Platform notes worth knowing
 
 - **Picker results must be read through security-scoped URLs.** A file chosen

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -162,14 +162,21 @@ endif()
 #   can drop captures in, and let juce::FileChooser open them in place.
 # - IPAD_SCREEN_ORIENTATIONS: the faceplate is landscape by design. iPhone is
 #   out of scope for this PR, so no iPhone orientation list.
+# - BUILD_VERSION: CFBundleVersion, which JUCE otherwise defaults to the
+#   marketing version. App Store Connect refuses a build number it has already
+#   seen for that marketing version, so with the default every upload after the
+#   first bounces. T3K_IOS_BUILD_NUMBER is a plain integer for CI to override.
 # The microphone and Bluetooth permission strings the plugin already declares
 # are the same keys iOS wants, so they are left in the shared block below.
 set(_t3k_ios_args "")
 if (T3K_IOS)
     set(T3K_IOS_BUNDLE_ID "com.TONE3000.TONE3000" CACHE STRING
         "Bundle identifier for the iOS app (override to sign under a personal team)")
+    set(T3K_IOS_BUILD_NUMBER "1" CACHE STRING
+        "CFBundleVersion for the iOS app: bump on every upload of one marketing version")
     set(_t3k_ios_args
         BUNDLE_ID "${T3K_IOS_BUNDLE_ID}"
+        BUILD_VERSION "${T3K_IOS_BUILD_NUMBER}"
         BACKGROUND_AUDIO_ENABLED TRUE
         FILE_SHARING_ENABLED TRUE
         DOCUMENT_BROWSER_ENABLED TRUE

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -269,14 +269,24 @@ if (T3K_IOS)
     else()
         file(GLOB _t3k_icons "${_t3k_iconset}/*.png")
         set(_t3k_flat "${CMAKE_CURRENT_BINARY_DIR}/_t3k_icon_opaque.png")
+        set(_t3k_missed "")
         foreach(_png ${_t3k_icons})
             execute_process(COMMAND "${T3K_MAGICK}" "${_png}" -alpha off "PNG24:${_t3k_flat}"
                             RESULT_VARIABLE _t3k_rc OUTPUT_QUIET ERROR_QUIET)
             if (_t3k_rc EQUAL 0 AND EXISTS "${_t3k_flat}")
                 file(RENAME "${_t3k_flat}" "${_png}")
+            else()
+                get_filename_component(_t3k_name "${_png}" NAME)
+                list(APPEND _t3k_missed "${_t3k_name}")
             endif()
         endforeach()
-        message(STATUS "iOS: app icons flattened to opaque")
+        if (_t3k_missed)
+            message(WARNING "iOS: ImageMagick could not flatten ${_t3k_missed}. Those icons keep "
+                            "their alpha channel, and an App Store Connect upload is rejected "
+                            "with ITMS-90717 if Icon-AppStore-1024.png is among them.")
+        else()
+            message(STATUS "iOS: app icons flattened to opaque")
+        endif()
     endif()
 
     # juceaide never enlarges the source (RectanglePlacement::onlyReduceInSize),

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -181,7 +181,10 @@ endif()
 # target already rides in the binary and MinimumOSVersion, so merging a macOS
 # key there would just be noise in the plist.
 if (T3K_IOS)
-    set(_t3k_plist_to_merge "")
+    # The app's only encryption is standard HTTPS, which is exempt. Declaring
+    # that here answers App Store Connect's export-compliance question once
+    # instead of on every TestFlight upload.
+    set(_t3k_plist_to_merge PLIST_TO_MERGE "<plist version=\"1.0\"><dict><key>ITSAppUsesNonExemptEncryption</key><false/></dict></plist>")
 else()
     set(_t3k_plist_to_merge PLIST_TO_MERGE "<plist version=\"1.0\"><dict><key>LSMinimumSystemVersion</key><string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string></dict></plist>")
 endif()
@@ -223,6 +226,64 @@ juce_add_plugin(${PROJECT_NAME}
     ${_t3k_ios_args}
     ICON_BIG "${_app_icon}"
 )
+
+# What App Store Connect checks on upload. Nothing here changes how the app
+# behaves; without it the upload is rejected or the icon goes missing.
+if (T3K_IOS)
+    # Apple's privacy manifest. An upload whose binary calls a "required
+    # reason" API the manifest does not declare is rejected with ITMS-91053.
+    # It belongs to the app target rather than the shared code, and iOS
+    # bundles are flat, so "Resources" is the bundle root.
+    set(_t3k_privacy "${CMAKE_CURRENT_SOURCE_DIR}/PrivacyInfo.xcprivacy")
+    target_sources(${PROJECT_NAME}_Standalone PRIVATE "${_t3k_privacy}")
+    set_source_files_properties("${_t3k_privacy}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+
+    # The 1024 App Store icon must carry no alpha channel: with one, App Store
+    # Connect returns ITMS-90717 and the icon never appears in TestFlight.
+    # juceaide writes every icon RGBA no matter what the source is - its own
+    # opaque pass reallocates through the native image type, which is 32-bit
+    # ARGB on macOS - so the channel is dropped here, after juce_add_plugin
+    # generated the icon set and before actool compiles it into Assets.car.
+    # The pixels are already opaque; only the channel goes.
+    # JUCE writes the icon set under the shared-code target's generated sources
+    # but in a folder named for the format target that owns the bundle.
+    get_target_property(_t3k_gen ${PROJECT_NAME} JUCE_GENERATED_SOURCES_DIRECTORY)
+    set(_t3k_iconset "${_t3k_gen}/${PROJECT_NAME}_Standalone/Images.xcassets/AppIcon.appiconset")
+    find_program(T3K_MAGICK NAMES magick convert)
+    if (NOT EXISTS "${_t3k_iconset}")
+        message(WARNING "iOS: no icon set at ${_t3k_iconset}. JUCE has moved it, so the icons "
+                        "keep their alpha channel and an App Store Connect upload is rejected "
+                        "with ITMS-90717.")
+    elseif (NOT T3K_MAGICK)
+        message(WARNING "iOS: ImageMagick (magick/convert) not found, so the app icons keep "
+                        "their alpha channel. A Simulator build is fine; an App Store Connect "
+                        "upload is rejected with ITMS-90717. brew install imagemagick, then "
+                        "reconfigure.")
+    else()
+        file(GLOB _t3k_icons "${_t3k_iconset}/*.png")
+        set(_t3k_flat "${CMAKE_CURRENT_BINARY_DIR}/_t3k_icon_opaque.png")
+        foreach(_png ${_t3k_icons})
+            execute_process(COMMAND "${T3K_MAGICK}" "${_png}" -alpha off "PNG24:${_t3k_flat}"
+                            RESULT_VARIABLE _t3k_rc OUTPUT_QUIET ERROR_QUIET)
+            if (_t3k_rc EQUAL 0 AND EXISTS "${_t3k_flat}")
+                file(RENAME "${_t3k_flat}" "${_png}")
+            endif()
+        endforeach()
+        message(STATUS "iOS: app icons flattened to opaque")
+    endif()
+
+    # juceaide never enlarges the source (RectanglePlacement::onlyReduceInSize),
+    # so anything under 1024 leaves the App Store icon sitting at its own size
+    # in the middle of a blank 1024 field. Width lives at byte 16 of a PNG.
+    file(READ "${_app_icon}" _t3k_png_head HEX LIMIT 20)
+    string(SUBSTRING "${_t3k_png_head}" 32 8 _t3k_png_width)
+    math(EXPR _t3k_png_width "0x${_t3k_png_width}")
+    if (_t3k_png_width LESS 1024)
+        message(WARNING "iOS: ${_app_icon} is ${_t3k_png_width}px wide. The App Store icon is "
+                        "1024x1024 and is not upscaled, so it will show the artwork at "
+                        "${_t3k_png_width}px on a blank field. Export the icon at 1024.")
+    endif()
+endif()
 
 target_sources(${PROJECT_NAME}
     PRIVATE

--- a/plugin/PrivacyInfo.xcprivacy
+++ b/plugin/PrivacyInfo.xcprivacy
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+    <!-- The app does not collect data on the developer's behalf. The optional
+         TONE3000 sign-in is the user's own account on tone3000.com; its token
+         stays on the device. -->
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <!-- Required-reason APIs. Every one of these is reached from JUCE, not
+         from plugin code, and the reason codes are the ones Apple publishes
+         for that use. Uploads are rejected (ITMS-91053) when a required-reason
+         API in the binary is missing here. -->
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+        <dict>
+            <!-- [[NSUserDefaults standardUserDefaults] synchronize] in
+                 juce_WebBrowserComponent_mac.mm, which iOS compiles too. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>CA92.1</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- stat() for File::getFileTimesInternal / getLastModificationTime
+                 in juce_SharedCode_posix.h. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>C617.1</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- statfs() for File::getBytesFreeOnVolume in
+                 juce_SharedCode_posix.h. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>85F4.1</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/plugin/PrivacyInfo.xcprivacy
+++ b/plugin/PrivacyInfo.xcprivacy
@@ -47,6 +47,18 @@
                 <string>85F4.1</string>
             </array>
         </dict>
+        <dict>
+            <!-- [[NSProcessInfo processInfo] systemUptime] timestamps every
+                 touch and scroll event in juce_UIViewComponentPeer_ios.mm.
+                 Also covers the mach_absolute_time calls in
+                 juce_SystemStats_mac.mm and juce_CoreMidi_mac.mm. -->
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array>
+                <string>35F9.1</string>
+            </array>
+        </dict>
     </array>
 </dict>
 </plist>


### PR DESCRIPTION
Opening this against `main` now that #60 and #95 are in, as asked on #55. Four things App Store Connect checks that a Simulator build never exercises, and the last of them is why the first three matter.

**`PrivacyInfo.xcprivacy`** — the required-reason APIs the binary reaches through JUCE, not through plugin code. `NSUserDefaults` from `juce_WebBrowserComponent_mac.mm`, which iOS compiles under `JUCE_MAC || JUCE_IOS`; `stat()` and `statfs()` from `juce_SharedCode_posix.h`; and system boot time, which is `[[NSProcessInfo processInfo] systemUptime]` timestamping every touch and scroll in `juce_UIViewComponentPeer_ios.mm` (:2241, :2261) and also covers the `mach_absolute_time` calls in `juce_SystemStats_mac.mm` and `juce_CoreMidi_mac.mm`. A missing declaration is ITMS-91053. It goes on the app target, and iOS bundles are flat, so `Resources` is the bundle root.

**Opaque icons.** juceaide writes every icon RGBA whatever the source is — its own opaque pass in `createiOSIconFiles` composites onto an `Image::RGB` but allocates that through the native image type, which is 32-bit ARGB on macOS, so the channel is back before the PNG is written. An alpha channel on the 1024 icon is ITMS-90717, and the icon then never appears in TestFlight. Stripped with ImageMagick right after `juce_add_plugin` generates the set and before actool compiles it; the loop names any file it could not flatten rather than leaving a half-stripped set looking clean. Without ImageMagick the configure step warns and Simulator builds are unaffected.

**`ITSAppUsesNonExemptEncryption`** false — the only encryption here is standard HTTPS, so this answers export compliance once instead of on every upload.

**`T3K_IOS_BUILD_NUMBER`** — CFBundleVersion, which JUCE otherwise defaults to the marketing version, so the app ships build `0.0.6`. App Store Connect refuses a build number it has already seen for a marketing version, which makes the first upload of any version the only one that works — and it fails at upload, after a green build, so it reads like a signing problem. A plain integer for CI to override.

There is also a configure warning while `plugin/icon/icon.png` is 512: `rescaleImageForIcon` uses `onlyReduceInSize` and never enlarges, so the App Store icon is currently that 512 artwork centred on a blank 1024 field. @woodybury's 1024 export silences it.

One unrelated commit rides along, since it edits the same file and is six lines: the Build block on this page starts with `npm ci && npm run build`, which cannot work on a clean checkout — `ui/package.json` resolves `@juce-framework/webview` from `libs/juce`, and `libs/juce` is what the first CMake configure creates. Following the page as written fails with `Cannot find module '@juce-framework/webview'`. The root README documents the bootstrap configure and the CI job does configure → npm → reconfigure; only this page was missing the first step. Happy to split it out if you would rather.

### Verification

@brunofgsaraiva built this branch (Xcode, iphonesimulator, Release) before the rebase and reported: configures and builds clean, the strip runs in the right order, `sips` shows `hasAlpha: no` on every generated PNG including `Icon-AppStore-1024.png`, and the bundle carries CFBundleVersion 1, `ITSAppUsesNonExemptEncryption` false, `PrivacyInfo.xcprivacy` at the root and an `Assets.car`. The boot-time entry and the flatten warning are his two review findings, both fixed here. I still have no Xcode, so the rebase onto `main` is unbuilt on my side.
