### PR TITLE
fix(ui): scroll the model/IR dropdown to the loaded item on open

### DIFF
--- a/ui/src/components/ModelSelect.tsx
+++ b/ui/src/components/ModelSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { ChevronLeft, ChevronRight, FolderClosed } from './icons';
 import { useDismissable } from '../hooks/useDismissable';
 import { LoadingDots } from './LoadingDots';
@@ -44,9 +44,21 @@ export const ModelSelect: React.FC<ModelSelectProps> = ({
   const [isOpen, setIsOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const activeOptionRef = useRef<HTMLDivElement | null>(null);
 
   const currentIndex = options.findIndex((opt) => opt.id === value);
   const selectedOption = options[currentIndex];
+
+  // Land on the loaded item instead of the top of the list (issue #85) - in
+  // a tone pack with dozens/hundreds of files, always opening at the top
+  // means scrolling to find where you already are. Keyed on `options` too,
+  // not just `isOpen`: the catalog fetch (see ChainBlock.tsx's
+  // handleModelsOpen) resolves *after* the dropdown opens, so the first
+  // render only has the stored single-item fallback - this re-fires once
+  // the real list lands and the active row actually exists to scroll to.
+  useEffect(() => {
+    if (isOpen) activeOptionRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [isOpen, options]);
 
   const handlePrev = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -216,6 +228,7 @@ export const ModelSelect: React.FC<ModelSelectProps> = ({
           {options.map((option, index) => (
             <div
               key={option.id}
+              ref={option.id === value ? activeOptionRef : undefined}
               onClick={() => handleSelect(option.id)}
               style={{
                 padding: '12rem 16rem',


### PR DESCRIPTION
## Summary

Reopening a model/IR dropdown always landed at the top of the list instead of the currently loaded file. In a tone pack with dozens or hundreds of models, that meant scrolling to find where you already were every time.

- The active row's index was already known (it drives the highlight and the prev/next chevrons) - no new plumbing needed to know *what* to scroll to.
- Added a ref on the active row and a `useEffect` that calls `scrollIntoView({ block: 'nearest' })` when the dropdown opens.
- Keyed on the `options` array as well as `isOpen`: the catalog fetch resolves *after* the dropdown opens (`ChainBlock.tsx`'s `handleModelsOpen`), so the first render only has the stored single-item fallback - the effect re-fires once the real list lands, so it still lands correctly on a cold catalog fetch, not just when the list was already cached.

Fixes #85

## Test plan

- [x] `npm run lint` / `npm run build` - clean
- [x] Manual verification in the Standalone app: opening the dropdown for a block with an already-loaded catalog scrolls straight to the active/highlighted row
- [x] Manual verification on a cold catalog fetch (dropdown opened before the model list has loaded): still lands on the active row once the list arrives, not stuck at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)