### PR TITLE
feat(ui): add FLAT button to reset block EQ bands to default

### DIFF
--- a/ui/src/components/ChainBlock.tsx
+++ b/ui/src/components/ChainBlock.tsx
@@ -328,6 +328,10 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
     });
   }, [actions, blockId]);
 
+  const handleResetEq = useCallback(() => {
+    actions.resetBlockEq(blockId);
+  }, [actions, blockId]);
+
   const handleShare = useCallback(async () => {
     if (await actions.shareBlock(block)) toast.show('Link Copied');
   }, [actions, block, toast]);
@@ -738,6 +742,18 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                         <EqCurveIcon />
                       </button>
                     </div>
+                    <span
+                      className={uiOffClass(!eqOn)}
+                      style={{ display: 'inline-flex', transition: 'opacity 0.2s ease' }}
+                    >
+                      <ChromeTextButton
+                        armed={false}
+                        help="Reset all EQ bands to default (flat)"
+                        onClick={handleResetEq}
+                      >
+                        FLAT
+                      </ChromeTextButton>
+                    </span>
                   </>
                 )}
                 <ChromeTextButton


### PR DESCRIPTION
## Summary

Adds a FLAT button to the block EQ view (next to the sliders/graph segmented toggle) that resets all 6 bands to their default/flat state.

- Wired directly to the existing native `resetBlockEq` function - a single call, one undo step - not a per-band loop (which would land as six separate undo steps).
- The native `resetBlockEq` backend and its full action-layer plumbing (`useChainActions.ts`, `useChainState.ts`, `Plugin.tsx`) already shipped previously and are unrelated to this PR - this adds only the missing UI button, wired to what's already there.

## Test plan

- [x] `npm run lint` / `npm run build` - clean
- [x] `npx prettier --check` on the changed file - clean
- [x] Manual verification in the Standalone app built from this branch: nudged a band off default, pressed FLAT, then Ctrl+Z once - EQ returned correctly to the pre-reset nudged value in a single undo step

🤖 Generated with [Claude Code](https://claude.com/claude-code)