### PR TITLE
iOS: flatten the app icons with ImageIO instead of ImageMagick

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -85,10 +85,12 @@ Simulator build.
   `juce_UIViewComponentPeer_ios.mm`, plus `mach_absolute_time`). An upload whose
   binary calls one of those without declaring it is rejected with ITMS-91053,
   so the list is worth re-deriving whenever the JUCE version moves.
-- The app icons are flattened to opaque at configure time with ImageMagick.
-  juceaide writes them RGBA whatever the source is, and an alpha channel on the
-  1024 icon means ITMS-90717 and no icon in TestFlight. Without ImageMagick the
-  configure step warns; Simulator builds are unaffected either way.
+- The app icons are flattened to opaque at configure time by
+  `script/flatten-icon-alpha.swift`, run through `xcrun swift`. juceaide writes
+  them RGBA whatever the source is, and an alpha channel on the 1024 icon means
+  ITMS-90717 and no icon in TestFlight. It uses ImageIO rather than a tool from
+  a package manager because every machine that can build this target already
+  has both, the GitHub macOS runner included.
 - `ITSAppUsesNonExemptEncryption` is false in the Info.plist. The app's only
   encryption is standard HTTPS, and declaring it here answers the
   export-compliance question once instead of on every upload.

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -252,40 +252,32 @@ if (T3K_IOS)
     # ARGB on macOS - so the channel is dropped here, after juce_add_plugin
     # generated the icon set and before actool compiles it into Assets.car.
     # The pixels are already opaque; only the channel goes.
+    #
+    # The rewrite uses ImageIO through a Swift script rather than a tool from
+    # the package manager: every machine that can build this target has Swift
+    # and ImageIO, and the GitHub macOS runner does not ship ImageMagick.
+    #
     # JUCE writes the icon set under the shared-code target's generated sources
     # but in a folder named for the format target that owns the bundle.
     get_target_property(_t3k_gen ${PROJECT_NAME} JUCE_GENERATED_SOURCES_DIRECTORY)
     set(_t3k_iconset "${_t3k_gen}/${PROJECT_NAME}_Standalone/Images.xcassets/AppIcon.appiconset")
-    find_program(T3K_MAGICK NAMES magick convert)
-    if (NOT EXISTS "${_t3k_iconset}")
+    file(GLOB _t3k_icons "${_t3k_iconset}/*.png")
+    if (NOT _t3k_icons)
         message(WARNING "iOS: no icon set at ${_t3k_iconset}. JUCE has moved it, so the icons "
                         "keep their alpha channel and an App Store Connect upload is rejected "
                         "with ITMS-90717.")
-    elseif (NOT T3K_MAGICK)
-        message(WARNING "iOS: ImageMagick (magick/convert) not found, so the app icons keep "
-                        "their alpha channel. A Simulator build is fine; an App Store Connect "
-                        "upload is rejected with ITMS-90717. brew install imagemagick, then "
-                        "reconfigure.")
     else()
-        file(GLOB _t3k_icons "${_t3k_iconset}/*.png")
-        set(_t3k_flat "${CMAKE_CURRENT_BINARY_DIR}/_t3k_icon_opaque.png")
-        set(_t3k_missed "")
-        foreach(_png ${_t3k_icons})
-            execute_process(COMMAND "${T3K_MAGICK}" "${_png}" -alpha off "PNG24:${_t3k_flat}"
-                            RESULT_VARIABLE _t3k_rc OUTPUT_QUIET ERROR_QUIET)
-            if (_t3k_rc EQUAL 0 AND EXISTS "${_t3k_flat}")
-                file(RENAME "${_t3k_flat}" "${_png}")
-            else()
-                get_filename_component(_t3k_name "${_png}" NAME)
-                list(APPEND _t3k_missed "${_t3k_name}")
-            endif()
-        endforeach()
-        if (_t3k_missed)
-            message(WARNING "iOS: ImageMagick could not flatten ${_t3k_missed}. Those icons keep "
-                            "their alpha channel, and an App Store Connect upload is rejected "
-                            "with ITMS-90717 if Icon-AppStore-1024.png is among them.")
-        else()
+        execute_process(
+            COMMAND xcrun swift "${CMAKE_CURRENT_SOURCE_DIR}/../script/flatten-icon-alpha.swift"
+                    ${_t3k_icons}
+            RESULT_VARIABLE _t3k_rc
+            ERROR_VARIABLE _t3k_err)
+        if (_t3k_rc EQUAL 0)
             message(STATUS "iOS: app icons flattened to opaque")
+        else()
+            message(WARNING "iOS: could not flatten the app icons (${_t3k_err}). They keep their "
+                            "alpha channel, and an App Store Connect upload is rejected with "
+                            "ITMS-90717.")
         endif()
     endif()
 

--- a/script/flatten-icon-alpha.swift
+++ b/script/flatten-icon-alpha.swift
@@ -1,0 +1,35 @@
+import Foundation
+import ImageIO
+import CoreGraphics
+import UniformTypeIdentifiers
+
+// Rewrites each PNG given on the command line without an alpha channel,
+// compositing over white. Apple rejects an App Store icon that has one.
+for path in CommandLine.arguments.dropFirst() {
+    let url = URL(fileURLWithPath: path)
+    guard let src = CGImageSourceCreateWithURL(url as CFURL, nil),
+          let image = CGImageSourceCreateImageAtIndex(src, 0, nil) else {
+        FileHandle.standardError.write("cannot read \(path)\n".data(using: .utf8)!)
+        exit(1)
+    }
+    let w = image.width, h = image.height
+    guard let ctx = CGContext(data: nil, width: w, height: h, bitsPerComponent: 8,
+                              bytesPerRow: 0, space: CGColorSpaceCreateDeviceRGB(),
+                              bitmapInfo: CGImageAlphaInfo.noneSkipLast.rawValue) else {
+        FileHandle.standardError.write("cannot allocate context for \(path)\n".data(using: .utf8)!)
+        exit(1)
+    }
+    ctx.setFillColor(CGColor(red: 1, green: 1, blue: 1, alpha: 1))
+    ctx.fill(CGRect(x: 0, y: 0, width: w, height: h))
+    ctx.draw(image, in: CGRect(x: 0, y: 0, width: w, height: h))
+    guard let flat = ctx.makeImage(),
+          let dest = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+        FileHandle.standardError.write("cannot write \(path)\n".data(using: .utf8)!)
+        exit(1)
+    }
+    CGImageDestinationAddImage(dest, flat, nil)
+    guard CGImageDestinationFinalize(dest) else {
+        FileHandle.standardError.write("cannot finalize \(path)\n".data(using: .utf8)!)
+        exit(1)
+    }
+}


### PR DESCRIPTION
Answers @woodybury's question on #55 — "runner image doesn't ship ImageMagick, should we do something different there or install?" — with *something different*, and @brunofgsaraiva's CI run is the evidence it needs fixing: the iOS configure step prints "ImageMagick (magick/convert) not found" and every icon keeps its alpha channel, which is exactly the state that gets an upload rejected with ITMS-90717.

Installing it on the runner fixes that one job and leaves the same trap for anyone configuring locally without ImageMagick — a warning, a green build, and an upload that bounces much later. So the dependency goes instead. `script/flatten-icon-alpha.swift` does the rewrite through ImageIO: read each PNG, draw it into a `noneSkipLast` bitmap context over white, write it back. Every machine that can build this target has Swift and ImageIO, the runner included, so the "not found" branch disappears along with the dependency.

The remaining warning branch is now for a genuine failure rather than a missing tool, and it reports the compiler's own stderr.

### Verified

Against a real juceaide icon set, generated by building juceaide from the pinned JUCE 9.0.1 and running `iosassets` on the repo's icon:

- All 19 PNGs come out `8-bit/color RGB`, no alpha, `Icon-AppStore-1024.png` included.
- `magick compare -metric AE` reports **0** differing pixels against what the ImageMagick path produced, so this is a like-for-like replacement, not a re-render.
- Driven through the actual CMake block, not a hand-written approximation: configure prints "iOS: app icons flattened to opaque", and pointing it at a missing script produces the warning with the error in it rather than passing silently.
- About 1.8s for the whole set on an M-series machine, once per configure.

Still no Xcode here, so this is verified at the icon-generation and CMake level rather than through a full iOS build.
