### PR TITLE
ci: upload the iOS app to TestFlight on a published Release

### DIFF
--- a/.github/workflows/deploy-testflight.yml
+++ b/.github/workflows/deploy-testflight.yml
@@ -1,0 +1,204 @@
+name: Deploy to TestFlight
+
+# Publishing a GitHub Release builds, signs and uploads the iOS app to App Store
+# Connect. Signing and upload both use an App Store Connect API key, so nothing
+# needs a keychain, a .p12 or a stored provisioning profile on the runner.
+#
+# workflow_dispatch runs the same pipeline against any ref. A build number
+# already on TestFlight is refused at upload, so the build number is the run
+# number rather than anything in the tree.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag / branch / SHA) to build and upload"
+        required: true
+        default: main
+
+concurrency:
+  group: testflight-deploy
+  cancel-in-progress: false
+
+jobs:
+  # The signing credentials live in the `builds` environment. A fork that does
+  # not have them should skip rather than fail, and the secrets context cannot
+  # be read from a job-level `if`, so the check is its own job whose output
+  # gates the real one.
+  preflight:
+    name: Signing credentials
+    runs-on: ubuntu-latest
+    environment: builds
+    outputs:
+      ready: ${{ steps.check.outputs.ready }}
+    steps:
+      - id: check
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          if [ -n "$ASC_KEY_ID" ] && [ -n "$ASC_ISSUER_ID" ] \
+            && [ -n "$ASC_API_KEY_BASE64" ] && [ -n "$APPLE_TEAM_ID" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::App Store Connect credentials are not set on this repository, skipping the upload."
+          fi
+
+  deploy:
+    name: TestFlight
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true'
+    # App Store Connect refuses builds made against an older iOS SDK, and the
+    # SDK comes from whichever Xcode the image ships, so this tracks the newest
+    # runner image rather than the one the Simulator job uses.
+    runs-on: macos-26
+    environment: builds
+    env:
+      BUILD_TYPE: Release
+      VITE_T3K_PUBLISHABLE_KEY: ${{ secrets.VITE_T3K_PUBLISHABLE_KEY }}
+      VITE_T3K_UPDATE_NOTICE: ${{ vars.VITE_T3K_UPDATE_NOTICE }}
+      ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+      ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.ref }}
+          submodules: recursive
+
+      - name: Select the newest Xcode
+        run: |
+          set -euo pipefail
+          latest=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1 || true)
+          if [ -n "$latest" ]; then sudo xcode-select -s "$latest"; fi
+          xcodebuild -version
+          xcodebuild -showsdks | grep -i iphoneos
+
+      - name: Read version
+        run: echo "T3K_VERSION=$(tr -d '[:space:]' < VERSION)" >> "$GITHUB_ENV"
+
+      # The release train and the source should agree. The build number is a
+      # separate integer and is not checked here.
+      - name: Check the release tag against VERSION
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "${TAG#v}" != "$T3K_VERSION" ]; then
+            echo "::error::Release tag ${TAG#v} does not match VERSION ($T3K_VERSION)."
+            exit 1
+          fi
+
+      - name: Cache CPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            libs/juce
+            libs/googletest
+            libs/clap-juce-extensions
+          key: cpm-deps-ios-device-${{ hashFiles('CMakeLists.txt', 'plugin/CMakeLists.txt') }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install the App Store Connect API key
+        env:
+          ASC_API_KEY_BASE64: ${{ secrets.ASC_API_KEY_BASE64 }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/private_keys"
+          KEY_PATH="$RUNNER_TEMP/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+          echo "$ASC_API_KEY_BASE64" | base64 --decode > "$KEY_PATH"
+          echo "ASC_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      # Same order as the other jobs: configure so CPM fetches JUCE, which the
+      # UI build needs, then reconfigure so the content-hashed UI assets are
+      # picked up. The ios-device preset signs for development, which an App
+      # Store export will not accept, so the identity is overridden here. The
+      # build number is the run number: App Store Connect refuses one it has
+      # already seen for a marketing version.
+      - name: Configure CMake (bootstrap)
+        run: |
+          cmake --preset ios-device \
+            -DT3K_IOS_BUILD_NUMBER=${{ github.run_number }} \
+            -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE=Automatic \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="Apple Distribution"
+
+      - name: Build UI
+        run: |
+          cd ui
+          npm ci
+          npm run build
+
+      - name: Reconfigure CMake
+        run: |
+          cmake --preset ios-device \
+            -DT3K_IOS_BUILD_NUMBER=${{ github.run_number }} \
+            -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM=${{ secrets.APPLE_TEAM_ID }} \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_STYLE=Automatic \
+            -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY="Apple Distribution"
+
+      - name: Archive
+        run: |
+          set -euo pipefail
+          xcodebuild -project build-ios-device/TONE3000.xcodeproj \
+            -scheme TONE3000_Standalone \
+            -configuration "$BUILD_TYPE" \
+            -destination 'generic/platform=iOS' \
+            -archivePath "$RUNNER_TEMP/TONE3000.xcarchive" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID" \
+            archive
+
+      # Written here rather than committed so the Apple team id stays a secret.
+      - name: Export the IPA
+        run: |
+          set -euo pipefail
+          cat > "$RUNNER_TEMP/exportOptions.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+              <key>method</key>
+              <string>app-store-connect</string>
+              <key>teamID</key>
+              <string>${{ secrets.APPLE_TEAM_ID }}</string>
+              <key>destination</key>
+              <string>export</string>
+              <key>uploadSymbols</key>
+              <true/>
+          </dict>
+          </plist>
+          PLIST
+          xcodebuild -exportArchive \
+            -archivePath "$RUNNER_TEMP/TONE3000.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist "$RUNNER_TEMP/exportOptions.plist" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath "$ASC_KEY_PATH" \
+            -authenticationKeyID "$ASC_KEY_ID" \
+            -authenticationKeyIssuerID "$ASC_ISSUER_ID"
+
+      - name: Upload to TestFlight
+        run: |
+          set -euo pipefail
+          IPA=$(ls "$RUNNER_TEMP/export"/*.ipa | head -1)
+          xcrun altool --upload-app -f "$IPA" -t ios \
+            --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+
+      - name: Remove the API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys"

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -100,6 +100,13 @@ Simulator build.
   version, so a second upload of one version needs
   `-DT3K_IOS_BUILD_NUMBER=<n>`. Without the setting at all, JUCE uses the
   marketing version as the build number and the second upload always bounces.
+- The **Deploy to TestFlight** workflow
+  (`.github/workflows/deploy-testflight.yml`) does the upload: publishing a
+  GitHub Release builds, signs and uploads, and `workflow_dispatch` runs the
+  same pipeline against any ref. Signing and upload both use an App Store
+  Connect API key from the `builds` environment, so no keychain or stored
+  profile is involved, and the build number is the workflow run number. A
+  repository without those credentials skips the job instead of failing.
 - App Store Connect requires uploads built against a current iOS SDK. A runner
   pinned to an older Xcode builds and signs fine and is then refused at upload,
   which reads as a signing problem and is not one.


### PR DESCRIPTION
The deploy workflow @woodybury asked for on #55. Publishing a GitHub Release builds, signs and uploads the iOS app; `workflow_dispatch` runs the same pipeline against any ref for a dry run.

Built to the shape you described:

- **`environment: builds`** on the job that needs the credentials, since that is where `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_API_KEY_BASE64` and `APPLE_TEAM_ID` now live.
- **Skips cleanly without them.** The `secrets` context cannot be read from a job-level `if`, so a small preflight job checks the four and gates the real one on its output. A fork without them gets a green skip and a notice, not a red X.
- **`exportOptions.plist` is written at run time** from `APPLE_TEAM_ID`, so the team id stays a secret instead of sitting in the tree.
- Signing and upload both use the API key — no keychain, no `.p12`, no stored profile. The key is written under `RUNNER_TEMP` and removed in an `always()` step.

Three things worth flagging, because they are not obvious:

1. **The `ios-device` preset signs with "Apple Development"**, which an App Store export will not accept. The job overrides it to automatic signing with "Apple Distribution" — the preset is right for a device build you install yourself, so I have not changed it.
2. **The build number is `github.run_number`.** App Store Connect refuses a build number it has already seen for a marketing version, so it cannot come from the tree; `T3K_IOS_BUILD_NUMBER` from #104 is what makes this settable.
3. **The runner is `macos-26`, not `macos-14`** like the Simulator job. App Store Connect refuses builds made against an older iOS SDK, and the SDK comes from whichever Xcode the image ships. This is the failure I hit on my own app: it builds, it signs, and it is refused at upload, which reads like a signing problem and is not one. The job prints the selected Xcode and its iPhoneOS SDK before building.

It also follows the configure → npm → reconfigure order the other jobs use.

### On ImageMagick

Not handled here — #109 removes the dependency instead, which is the answer to your question on #55. The runner has no ImageMagick, so as things stand today the icons keep their alpha channel on CI and the upload this workflow performs would be rejected with ITMS-90717. **Merge #109 before cutting a build**, or add a `brew install imagemagick` step here — one line, about a minute on the runner, and then #109 removes it again.

### What is and isn't verified

The YAML parses, the generated `exportOptions.plist` passes `plutil -lint` with the expected keys, and the paths match this repo (`build-ios-device/TONE3000.xcodeproj`, scheme `TONE3000_Standalone`, artefacts under `plugin/TONE3000_artefacts/Release/Standalone`). The pipeline shape — API-key cloud signing, archive, export, `altool` upload — is one I have run to a successful TestFlight upload on my own JUCE iPad app.

What I cannot check from here: no Xcode on this machine, and no way to exercise a signed archive or a real upload against your team. The first run is the real test, and `workflow_dispatch` exists so it can be a dry run against `main` before you cut a Release.
