### PR TITLE
iOS: Measurement mode without HFP in one call, and the Bluetooth rate cap in the UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: ui/package-lock.json
 
@@ -200,11 +200,12 @@ jobs:
           npm run build
           cd ..
 
-      - name: Lint UI (Linux)
+      - name: Lint and test UI (Linux)
         if: matrix.os == 'linux'
         run: |
           cd ui
           npm run lint
+          npm run test
 
       - name: Reconfigure CMake (macOS arm64)
         if: matrix.os == 'macos'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -601,7 +601,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: ui/package-lock.json
 

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -131,7 +131,12 @@ Simulator build.
     low-rate headset *mic* route goes away. It is not a JUCE text patch:
     JUCE sets the category when it *opens* a device and never on its own
     route-change `restart()` path, so re-applying it on every device-manager
-    change is enough and the JUCE tree stays untouched.
+    change is enough and the JUCE tree stays untouched. What was verified:
+    the rate is right when the device is (re)opened after the option is
+    gone. Whether a session already running at 24 kHz climbs back to 48 kHz
+    the moment HFP is dropped, without a reopen, is not confirmed on a
+    device: JUCE's `handleRouteChange` ignores `CategoryChange` and
+    `RouteConfigurationChange`, so it depends on which reason iOS reports.
   - `isBluetoothRoute()` feeds `bluetoothRoute` in the settings state, and
     the UI turns that (or any session under 44.1 kHz) into one plain tip in
     Settings > System Settings, next to Sample Rate: use wired headphones,

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -125,18 +125,26 @@ Simulator build.
   microphone wins the route and iOS refuses the requested 48 kHz. Two answers
   ship together, both in `IosAudioRoute` (the Haptics / AudioPermissions
   shim pattern, header-only no-op off iOS):
-  - `disallowBluetoothHfp()` re-sets the session category without that one
-    option, keeping every other option JUCE asked for, `AllowBluetoothA2DP`
-    included, so Bluetooth output-only listening still works and only the
-    low-rate headset *mic* route goes away. It is not a JUCE text patch:
-    JUCE sets the category when it *opens* a device and never on its own
-    route-change `restart()` path, so re-applying it on every device-manager
-    change is enough and the JUCE tree stays untouched. What was verified:
-    the rate is right when the device is (re)opened after the option is
-    gone. Whether a session already running at 24 kHz climbs back to 48 kHz
-    the moment HFP is dropped, without a reopen, is not confirmed on a
-    device: JUCE's `handleRouteChange` ignores `CategoryChange` and
-    `RouteConfigurationChange`, so it depends on which reason iOS reports.
+  - `configureSession()` makes one `setCategory:mode:options:` call: the
+    category and options JUCE asked for, minus `AllowBluetoothHFP`, with
+    Measurement mode (the raw input path). `AllowBluetoothA2DP` stays, so
+    Bluetooth output-only listening still works and only the low-rate
+    headset *mic* route goes away. Mode and options go in one call on
+    purpose: on iPadOS 26 a bare `setMode:` clears category options.
+    Measured on an iPad Pro: from Default mode `0x69` became `0x1` (A2DP,
+    AirPlay and DefaultToSpeaker all gone); with the mode already
+    Measurement, a repeated `setMode:` turned `0x69` into `0x61`
+    (DefaultToSpeaker gone). It is not a JUCE text patch: JUCE sets the
+    category when it *opens* a device and never on its own route-change
+    `restart()` path, so re-applying it on every device-manager change is
+    enough and the JUCE tree stays untouched. Measured on an iPad Pro
+    (iPadOS 26) with AirPods Pro connected, reading `AVAudioSession` from
+    the app log: the first open with HFP allowed came up at 24 kHz; after
+    the call the device reopened at 48 kHz on the built-in mic. With a USB
+    interface unplugged mid-session, the route went to the built-in mic at
+    48 kHz, then to built-in mic plus AirPods A2DP output at 48 kHz, and
+    back to the interface when it was plugged in again, with options `0x69`
+    and Measurement mode held through every change.
   - `isBluetoothRoute()` feeds `bluetoothRoute` in the settings state, and
     the UI turns that (or any session under 44.1 kHz) into one plain tip in
     Settings > System Settings, next to Sample Rate: use wired headphones,

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -117,6 +117,27 @@ Simulator build.
   file name under the current stash folder; a path that still exists is used
   as-is, which is every desktop case. Presets and project state were never
   affected: they embed the model bytes.
+- **Bluetooth headphones cap the whole session at 16 or 24 kHz.** The owner
+  hit this on the iPad with AirPods: `prepareToPlay: sampleRate=24000` and a
+  sample-rate warning in Settings with nothing saying why. JUCE opens the iOS
+  session as `PlayAndRecord` with `AllowBluetoothHFP`
+  (`juce_Audio_ios.cpp`, `setAudioSessionCategory`), so a headset with a
+  microphone wins the route and iOS refuses the requested 48 kHz. Two answers
+  ship together, both in `IosAudioRoute` (the Haptics / AudioPermissions
+  shim pattern, header-only no-op off iOS):
+  - `disallowBluetoothHfp()` re-sets the session category without that one
+    option, keeping every other option JUCE asked for, `AllowBluetoothA2DP`
+    included, so Bluetooth output-only listening still works and only the
+    low-rate headset *mic* route goes away. It is not a JUCE text patch:
+    JUCE sets the category when it *opens* a device and never on its own
+    route-change `restart()` path, so re-applying it on every device-manager
+    change is enough and the JUCE tree stays untouched.
+  - `isBluetoothRoute()` feeds `bluetoothRoute` in the settings state, and
+    the UI turns that (or any session under 44.1 kHz) into one plain tip in
+    Settings > System Settings, next to Sample Rate: use wired headphones,
+    the iPad speaker, or a USB audio interface. The generic "runs lightest
+    at 48 kHz" note is suppressed while it shows, so there is one
+    explanation instead of two.
 - `xcrun simctl privacy grant microphone` does not suppress the prompt;
   `AVAudioSession` still asks once.
 - **`UIRequiresFullScreen` no longer opts an app out of multitasking** on

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -117,9 +117,9 @@ Simulator build.
   file name under the current stash folder; a path that still exists is used
   as-is, which is every desktop case. Presets and project state were never
   affected: they embed the model bytes.
-- **Bluetooth headphones cap the whole session at 16 or 24 kHz.** The owner
-  hit this on the iPad with AirPods: `prepareToPlay: sampleRate=24000` and a
-  sample-rate warning in Settings with nothing saying why. JUCE opens the iOS
+- **Bluetooth headphones cap the whole session at 16 or 24 kHz.** We hit this
+  on an iPad with AirPods: `prepareToPlay: sampleRate=24000` and a sample-rate
+  warning in Settings with nothing saying why. JUCE opens the iOS
   session as `PlayAndRecord` with `AllowBluetoothHFP`
   (`juce_Audio_ios.cpp`, `setAudioSessionCategory`), so a headset with a
   microphone wins the route and iOS refuses the requested 48 kHz. Two answers
@@ -137,14 +137,14 @@ Simulator build.
     (DefaultToSpeaker gone). It is not a JUCE text patch: JUCE sets the
     category when it *opens* a device and never on its own route-change
     `restart()` path, so re-applying it on every device-manager change is
-    enough and the JUCE tree stays untouched. Measured on an iPad Pro
-    (iPadOS 26) with AirPods Pro connected, reading `AVAudioSession` from
-    the app log: the first open with HFP allowed came up at 24 kHz; after
-    the call the device reopened at 48 kHz on the built-in mic. With a USB
-    interface unplugged mid-session, the route went to the built-in mic at
-    48 kHz, then to built-in mic plus AirPods A2DP output at 48 kHz, and
-    back to the interface when it was plugged in again, with options `0x69`
-    and Measurement mode held through every change.
+    enough and the JUCE tree stays untouched. On the same iPad Pro, with
+    AirPods Pro connected and reading `AVAudioSession` from the app log:
+    the first open with HFP allowed came up at 24 kHz; after the call the
+    device reopened at 48 kHz on the built-in mic. With a USB interface
+    unplugged mid-session, the route went to the built-in mic at 48 kHz,
+    then to built-in mic plus AirPods A2DP output at 48 kHz, and back to
+    the interface when it was plugged in again, with options `0x69` and
+    Measurement mode held through every change.
   - `isBluetoothRoute()` feeds `bluetoothRoute` in the settings state, and
     the UI turns that (or any session under 44.1 kHz) into one plain tip in
     Settings > System Settings, next to Sample Rate: use wired headphones,

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -348,6 +348,8 @@ if (NOT HEADLESS)
     # OS microphone-permission shim: AVFoundation (ObjC++) on macOS, a
     # best-effort stub elsewhere (see AudioPermissions.h).
     target_sources(${PROJECT_NAME} PRIVATE include/AudioPermissions.h)
+    # iOS audio-route shim; header-only no-op on Windows and Linux.
+    target_sources(${PROJECT_NAME} PRIVATE include/IosAudioRoute.h)
     # Webview session clearing is platform-specific: WKWebsiteDataStore needs
     # ObjC++ on Apple; elsewhere a best-effort JUCE fallback.
     if (APPLE)
@@ -357,6 +359,9 @@ if (NOT HEADLESS)
         # Space passthrough to the host DAW (see WindowKeyEvents.mm).
         target_sources(${PROJECT_NAME} PRIVATE src/WindowKeyEvents.mm)
         target_sources(${PROJECT_NAME} PRIVATE src/AudioPermissions.mm)
+        # AVAudioSession route query + the Bluetooth HFP opt-out (see
+        # IosAudioRoute.h).
+        target_sources(${PROJECT_NAME} PRIVATE src/IosAudioRoute.mm)
     else()
         target_sources(${PROJECT_NAME} PRIVATE src/WebViewCookies.cpp)
         # Space passthrough to the host DAW (see WindowKeyEvents.cpp).

--- a/plugin/include/IosAudioRoute.h
+++ b/plugin/include/IosAudioRoute.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <juce_core/juce_core.h>
+
+/**
+ * iOS audio-route shim (a no-op everywhere else).
+ *
+ * JUCE's iOS device opens the session as PlayAndRecord with
+ * AllowBluetoothHFP (juce_Audio_ios.cpp, setAudioSessionCategory), so a
+ * Bluetooth headset with a microphone becomes the whole route and iOS caps
+ * the session at 16 or 24 kHz, refusing the requested 48 kHz. The owner hit
+ * exactly that with AirPods: `prepareToPlay: sampleRate=24000` and no
+ * explanation in the UI.
+ *
+ * Two answers, both here: tell the user what happened (isBluetoothRoute
+ * feeds the settings tip), and stop asking for the HFP route in the first
+ * place (disallowBluetoothHfp). A2DP stays allowed, so Bluetooth output-only
+ * listening still works; only the low-rate headset *mic* route goes away.
+ *
+ * Same platform-shim pattern as Haptics / AudioPermissions: one header, one
+ * ObjC++ implementation, a header-only no-op off iOS so desktop links.
+ */
+namespace IosAudioRoute {
+
+#if JUCE_IOS
+
+/** True when the session's current output route is Bluetooth (HFP, A2DP or
+    LE). Cheap enough to call on every state pull. */
+bool isBluetoothRoute();
+
+/** Re-set the session category without AllowBluetoothHFP, keeping every other
+    option JUCE asked for (including A2DP and MixWithOthers). Idempotent, and
+    a no-op unless the option is actually set, so it can be called after every
+    device-manager change: JUCE only sets the category when it opens a device,
+    never on the route-change restart path, so re-applying is how the override
+    survives a reopen. */
+void disallowBluetoothHfp();
+
+#else
+
+inline bool isBluetoothRoute() {
+  return false;
+}
+inline void disallowBluetoothHfp() {}
+
+#endif
+
+}  // namespace IosAudioRoute

--- a/plugin/include/IosAudioRoute.h
+++ b/plugin/include/IosAudioRoute.h
@@ -8,8 +8,8 @@
  * JUCE's iOS device opens the session as PlayAndRecord with
  * AllowBluetoothHFP (juce_Audio_ios.cpp, setAudioSessionCategory), so a
  * Bluetooth headset with a microphone becomes the whole route and iOS caps
- * the session at 16 or 24 kHz, refusing the requested 48 kHz. The owner hit
- * exactly that with AirPods: `prepareToPlay: sampleRate=24000` and no
+ * the session at 16 or 24 kHz, refusing the requested 48 kHz. We hit exactly
+ * that on an iPad with AirPods: `prepareToPlay: sampleRate=24000` and no
  * explanation in the UI.
  *
  * Two answers, both here: tell the user what happened (isBluetoothRoute

--- a/plugin/include/IosAudioRoute.h
+++ b/plugin/include/IosAudioRoute.h
@@ -14,8 +14,9 @@
  *
  * Two answers, both here: tell the user what happened (isBluetoothRoute
  * feeds the settings tip), and stop asking for the HFP route in the first
- * place (disallowBluetoothHfp). A2DP stays allowed, so Bluetooth output-only
- * listening still works; only the low-rate headset *mic* route goes away.
+ * place (configureSession, which also holds Measurement mode). A2DP stays
+ * allowed, so Bluetooth output-only listening still works; only the
+ * low-rate headset *mic* route goes away.
  *
  * Same platform-shim pattern as Haptics / AudioPermissions: one header, one
  * ObjC++ implementation, a header-only no-op off iOS so desktop links.
@@ -28,20 +29,25 @@ namespace IosAudioRoute {
     LE). Cheap enough to call on every state pull. */
 bool isBluetoothRoute();
 
-/** Re-set the session category without AllowBluetoothHFP, keeping every other
-    option JUCE asked for (including A2DP and MixWithOthers). Idempotent, and
-    a no-op unless the option is actually set, so it can be called after every
+/** One setCategory:mode:options: call: the category and options JUCE asked
+    for minus AllowBluetoothHFP, with Measurement mode (the raw input path, no
+    AGC and no voice processing). Mode and options go together because a bare
+    setMode: clears category options on iPadOS 26. Measured: from Default
+    mode 0x69 became 0x1 (A2DP, AirPlay and DefaultToSpeaker all gone); with
+    the mode already Measurement, a repeated setMode: turned 0x69 into 0x61
+    (DefaultToSpeaker gone). Playback (no input channels) is left alone:
+    nothing to keep raw there. Idempotent, so it can be called after every
     device-manager change: JUCE only sets the category when it opens a device,
     never on the route-change restart path, so re-applying is how the override
     survives a reopen. */
-void disallowBluetoothHfp();
+void configureSession();
 
 #else
 
 inline bool isBluetoothRoute() {
   return false;
 }
-inline void disallowBluetoothHfp() {}
+inline void configureSession() {}
 
 #endif
 

--- a/plugin/include/StandaloneAudioSettings.h
+++ b/plugin/include/StandaloneAudioSettings.h
@@ -137,8 +137,8 @@ private:
   bool applyRememberedSetup(const juce::var& saved);
   void rememberCurrentSetup();
 
-  /** iOS: hold the audio session in Measurement mode (see the .cpp). Does
-      nothing on any other platform. */
+  /** iOS: hold the audio session in Measurement mode, without the Bluetooth
+      HFP route (see the .cpp). Does nothing on any other platform. */
   void applyRawInputMode();
 
   /** Follow the feedback-risk heuristic unless the user has overridden. */

--- a/plugin/src/EditorWebViewSetup.cpp
+++ b/plugin/src/EditorWebViewSetup.cpp
@@ -778,6 +778,15 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
 #endif
             return juce::var(true);
           }))
+#if JUCE_IOS
+      // Platform flag for the web UI, injected at document start so the very
+      // first paint already knows. iOS is the only build whose window is a
+      // fixed, full-screen box the UI cannot resize, which changes how the UI
+      // fits its design box (see useUiScale) and which pointer gestures it
+      // offers. Set only here, so every desktop build's injected script is
+      // byte-identical to before.
+      .withUserScript(R"(window.__T3K_PLATFORM__ = 'ios';)")
+#endif
       .withUserScript(R"(
             document.documentElement.style.backgroundColor = '#000000';
             // This script runs at document start, where document.body is still

--- a/plugin/src/IosAudioRoute.mm
+++ b/plugin/src/IosAudioRoute.mm
@@ -45,9 +45,11 @@ void disallowBluetoothHfp() {
   if ((options & hfp) == 0)
     return;
 
-  [session setCategory:session.category
-           withOptions:(options & ~hfp)
-                 error:nil];
+  NSError* error = nil;
+  if (! [session setCategory:session.category withOptions:(options & ~hfp) error:&error])
+    DBG ("IosAudioRoute: could not drop the HFP option: "
+         << (error != nil ? juce::String::fromUTF8 ([[error localizedDescription] UTF8String])
+                          : juce::String ("no error object")));
 }
 
 }  // namespace IosAudioRoute

--- a/plugin/src/IosAudioRoute.mm
+++ b/plugin/src/IosAudioRoute.mm
@@ -1,0 +1,55 @@
+#include "IosAudioRoute.h"
+
+#if JUCE_IOS
+
+#import <AVFoundation/AVFoundation.h>
+
+namespace IosAudioRoute {
+
+bool isBluetoothRoute() {
+  AVAudioSession* session = [AVAudioSession sharedInstance];
+  for (AVAudioSessionPortDescription* output in session.currentRoute.outputs) {
+    NSString* type = output.portType;
+    if ([type isEqualToString:AVAudioSessionPortBluetoothHFP] ||
+        [type isEqualToString:AVAudioSessionPortBluetoothA2DP] ||
+        [type isEqualToString:AVAudioSessionPortBluetoothLE])
+      return true;
+  }
+  // A headset mic can be the input while the output is still the speaker.
+  for (AVAudioSessionPortDescription* input in session.currentRoute.inputs)
+    if ([input.portType isEqualToString:AVAudioSessionPortBluetoothHFP])
+      return true;
+  return false;
+}
+
+void disallowBluetoothHfp() {
+  AVAudioSession* session = [AVAudioSession sharedInstance];
+
+  // Only PlayAndRecord carries the option; leave Playback alone.
+  if (![session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord])
+    return;
+
+  // Take JUCE's own options and clear one bit, rather than rebuilding the
+  // set: MixWithOthers, DefaultToSpeaker, AllowAirPlay and A2DP stay exactly
+  // as JUCE asked for them, whatever the JUCE version decided.
+  const AVAudioSessionCategoryOptions options = session.categoryOptions;
+
+  // Same SDK gate JUCE uses for the same constant (it was renamed in the
+  // iOS 26 SDK; the value is unchanged).
+ #if JUCE_IOS_API_VERSION_CAN_BE_BUILT (26, 0)
+  constexpr auto hfp = AVAudioSessionCategoryOptionAllowBluetoothHFP;
+ #else
+  constexpr auto hfp = AVAudioSessionCategoryOptionAllowBluetooth;
+ #endif
+
+  if ((options & hfp) == 0)
+    return;
+
+  [session setCategory:session.category
+           withOptions:(options & ~hfp)
+                 error:nil];
+}
+
+}  // namespace IosAudioRoute
+
+#endif

--- a/plugin/src/IosAudioRoute.mm
+++ b/plugin/src/IosAudioRoute.mm
@@ -51,15 +51,20 @@ void configureSession() {
       && [session.mode isEqualToString:AVAudioSessionModeMeasurement])
     return;
 
-  // One retry: the first call can be refused while a USB route is still
-  // settling, and nothing else re-applies this until the next change.
+  // Two attempts, back to back with no delay, so the second one only covers
+  // a refusal the OS clears immediately (a route still settling as the call
+  // lands). Anything slower than that is not retried here: the next route
+  // change re-applies this anyway. Each attempt starts from a fresh error so
+  // the log below describes the attempt that actually failed last.
   NSError* error = nil;
-  for (int attempt = 0; attempt < 2; ++attempt)
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    error = nil;
     if ([session setCategory:session.category
                         mode:AVAudioSessionModeMeasurement
                      options:options
                        error:&error])
       return;
+  }
 
   DBG ("IosAudioRoute: could not set Measurement mode without HFP: "
        << (error != nil ? juce::String::fromUTF8 ([[error localizedDescription] UTF8String])

--- a/plugin/src/IosAudioRoute.mm
+++ b/plugin/src/IosAudioRoute.mm
@@ -22,17 +22,12 @@ bool isBluetoothRoute() {
   return false;
 }
 
-void disallowBluetoothHfp() {
+void configureSession() {
   AVAudioSession* session = [AVAudioSession sharedInstance];
 
   // Only PlayAndRecord carries the option; leave Playback alone.
   if (![session.category isEqualToString:AVAudioSessionCategoryPlayAndRecord])
     return;
-
-  // Take JUCE's own options and clear one bit, rather than rebuilding the
-  // set: MixWithOthers, DefaultToSpeaker, AllowAirPlay and A2DP stay exactly
-  // as JUCE asked for them, whatever the JUCE version decided.
-  const AVAudioSessionCategoryOptions options = session.categoryOptions;
 
   // Same SDK gate JUCE uses for the same constant (it was renamed in the
   // iOS 26 SDK; the value is unchanged).
@@ -42,14 +37,33 @@ void disallowBluetoothHfp() {
   constexpr auto hfp = AVAudioSessionCategoryOptionAllowBluetooth;
  #endif
 
-  if ((options & hfp) == 0)
+  // Take JUCE's own options and clear one bit, rather than rebuilding the
+  // set: MixWithOthers, DefaultToSpeaker, AllowAirPlay and A2DP stay exactly
+  // as JUCE asked for them, whatever the JUCE version decided. They are read
+  // from the live session, so this never adds an option back; JUCE sets the
+  // full set again on the next device open.
+  const AVAudioSessionCategoryOptions options = session.categoryOptions & ~hfp;
+
+  // Also what ends the loop: our own setCategory raises a CategoryChange
+  // route notification, the device type forwards every reason to the
+  // device-manager broadcast, and that lands here again.
+  if (options == session.categoryOptions
+      && [session.mode isEqualToString:AVAudioSessionModeMeasurement])
     return;
 
+  // One retry: the first call can be refused while a USB route is still
+  // settling, and nothing else re-applies this until the next change.
   NSError* error = nil;
-  if (! [session setCategory:session.category withOptions:(options & ~hfp) error:&error])
-    DBG ("IosAudioRoute: could not drop the HFP option: "
-         << (error != nil ? juce::String::fromUTF8 ([[error localizedDescription] UTF8String])
-                          : juce::String ("no error object")));
+  for (int attempt = 0; attempt < 2; ++attempt)
+    if ([session setCategory:session.category
+                        mode:AVAudioSessionModeMeasurement
+                     options:options
+                       error:&error])
+      return;
+
+  DBG ("IosAudioRoute: could not set Measurement mode without HFP: "
+       << (error != nil ? juce::String::fromUTF8 ([[error localizedDescription] UTF8String])
+                        : juce::String ("no error object")));
 }
 
 }  // namespace IosAudioRoute

--- a/plugin/src/StandaloneAudioSettings.cpp
+++ b/plugin/src/StandaloneAudioSettings.cpp
@@ -117,10 +117,8 @@ StandaloneAudioSettings::StandaloneAudioSettings(TONE3000Processor& p,
   jassert(isAvailable());
   if (auto* dm = deviceManager())
     dm->addChangeListener(this);
-  // iOS: drop the Bluetooth headset mic route JUCE asks for (see
-  // IosAudioRoute.h). No-op off iOS. Category first, then mode: Apple
-  // recommends setting them together, and setCategory clears the mode.
-  IosAudioRoute::disallowBluetoothHfp();
+  // iOS: Measurement mode, and no Bluetooth headset mic route (see
+  // IosAudioRoute.h). No-op off iOS.
   applyRawInputMode();
   ensureInitialPolicies();
 }
@@ -139,9 +137,6 @@ void StandaloneAudioSettings::changeListenerCallback(juce::ChangeBroadcaster*) {
   // Fires for every device-manager change: our own setters, hot-plugs,
   // devices vanishing mid-session, vendor control panel edits. Re-run the
   // sync policies, then push the UI to re-pull state.
-  // Category before mode: JUCE sets the category when it opens a device,
-  // which clears the mode, so both are re-applied here in that order.
-  IosAudioRoute::disallowBluetoothHfp();
   applyRawInputMode();
   ensureInitialPolicies();
   applyMonitoringPolicy();
@@ -817,31 +812,25 @@ void StandaloneAudioSettings::rememberCurrentSetup() {
 
 void StandaloneAudioSettings::applyRawInputMode() {
 #if JUCE_IOS
-  auto* dm = deviceManager();
-  auto* device = dm != nullptr ? dm->getCurrentAudioDevice() : nullptr;
-  if (device == nullptr)
-    return;
-
   // JUCE opens the session with setCategory: and no mode, so it stays in
   // AVAudioSessionModeDefault - the voice chain. Its AGC levels the guitar
   // before the model ever sees it (pick attack and the guitar's volume knob
   // stop coming through), and the processing inflates
   // AVAudioSession.inputLatency, the figure the settings UI reports.
-  // setAudioPreprocessingEnabled(false) is Measurement mode, the raw path.
+  // Measurement mode is the raw path.
+  //
+  // The mode goes in one setCategory:mode:options: call together with the
+  // category options, never through setMode: alone: on iPadOS 26 a bare
+  // setMode: from Default mode cleared the category options to MixWithOthers
+  // only, which cost the A2DP, AirPlay and DefaultToSpeaker options JUCE
+  // asked for. The same call drops AllowBluetoothHFP, the option that lets a
+  // headset mic cap the whole session at 16 or 24 kHz (see IosAudioRoute.h).
   //
   // setCategory: clears the session mode, and JUCE calls it every time a
   // device opens, so this cannot be done once at startup. Device opens and
   // route changes both end up at the device manager's change broadcast, which
   // is where this is re-applied from.
-  //
-  // The retry covers a USB route restart, where the first setMode: can be
-  // dropped while the route is still settling. Nothing is reported on a second
-  // refusal: JUCE returns `session.mode == mode`, an NSString pointer
-  // comparison rather than isEqualToString:, so a false is not evidence the
-  // mode failed to take, and a log built on it would send someone chasing a
-  // session that is already in Measurement mode.
-  if (!device->setAudioPreprocessingEnabled(false))
-    device->setAudioPreprocessingEnabled(false);
+  IosAudioRoute::configureSession();
 #endif
 }
 

--- a/plugin/src/StandaloneAudioSettings.cpp
+++ b/plugin/src/StandaloneAudioSettings.cpp
@@ -1,6 +1,7 @@
 #include "StandaloneAudioSettings.h"
 
 #include "AudioPermissions.h"
+#include "IosAudioRoute.h"
 #include "Processor.h"
 
 // The standalone filter window header expects the full GUI/audio module set
@@ -116,6 +117,10 @@ StandaloneAudioSettings::StandaloneAudioSettings(TONE3000Processor& p,
   jassert(isAvailable());
   if (auto* dm = deviceManager())
     dm->addChangeListener(this);
+  // iOS: drop the Bluetooth headset mic route JUCE asks for (see
+  // IosAudioRoute.h). No-op off iOS. Category first, then mode: Apple
+  // recommends setting them together, and setCategory clears the mode.
+  IosAudioRoute::disallowBluetoothHfp();
   applyRawInputMode();
   ensureInitialPolicies();
 }
@@ -134,6 +139,9 @@ void StandaloneAudioSettings::changeListenerCallback(juce::ChangeBroadcaster*) {
   // Fires for every device-manager change: our own setters, hot-plugs,
   // devices vanishing mid-session, vendor control panel edits. Re-run the
   // sync policies, then push the UI to re-pull state.
+  // Category before mode: JUCE sets the category when it opens a device,
+  // which clears the mode, so both are re-applied here in that order.
+  IosAudioRoute::disallowBluetoothHfp();
   applyRawInputMode();
   ensureInitialPolicies();
   applyMonitoringPolicy();
@@ -239,6 +247,11 @@ juce::var StandaloneAudioSettings::getState() {
   // OS mic gate: on macOS a "denied" state silently kills all audio input,
   // so the UI surfaces it (banner + inline alert) with a jump to the fix.
   obj->setProperty("micPermission", micStatusString(AudioPermissions::getMicStatus()));
+
+  // iOS: a Bluetooth route caps the session at 16 or 24 kHz and adds
+  // latency; the UI turns this into one plain-language tip. Always false on
+  // desktop.
+  obj->setProperty("bluetoothRoute", IosAudioRoute::isBluetoothRoute());
 
   // MIDI inputs, re-enumerated per pull like the audio devices above (the UI
   // polls while the tab is open, which is also our hot-plug detection; the

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,10 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "lint": "eslint src",
+    "lint": "eslint src test",
     "test": "node --test \"test/*.test.ts\"",
-    "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\""
+    "format": "prettier --write \"{src,test}/**/*.{ts,tsx,css}\"",
+    "format:check": "prettier --check \"{src,test}/**/*.{ts,tsx,css}\""
   },
   "dependencies": {
     "@dnd-kit/helpers": "^0.5.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "lint": "eslint src",
+    "test": "node --test \"test/*.test.ts\"",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\""
   },

--- a/ui/src/components/AppBanner.tsx
+++ b/ui/src/components/AppBanner.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import type { AudioDeviceState } from '../types/audioDevice';
+import { shouldShowBluetoothTip, type AudioDeviceState } from '../types/audioDevice';
+import { IS_IOS } from '../hooks/useUiScale';
 import { AlertIcon, type AlertVariant } from './controls';
 import { BORDER, MUTED } from './theme';
 
@@ -175,6 +176,24 @@ const BANNER_RULES: BannerRule[] = [
         <b>Noticeable delay?</b> Your buffer is {state.bufferSize} samples (
         {((state.bufferSize * 1000) / (state.sampleRate || 48000)).toFixed(1)} ms). Lowering it to
         256 or less will feel more responsive.
+      </>
+    ),
+    action: { label: 'Open Settings', kind: 'openSettings' },
+  },
+  {
+    // iOS only: with AirPods (or any headset) connected the session comes up
+    // on the Bluetooth route, which iOS caps at 16 or 24 kHz and gives extra
+    // latency. Ranked above rate-not-48k because it is the *cause* of the low
+    // rate, and the generic "runs lightest at 48 kHz" note explains nothing
+    // an iPad user can act on. Desktop never evaluates it (IS_IOS is false).
+    id: 'bluetooth-route',
+    variant: 'info',
+    dismissable: true,
+    when: (state) => IS_IOS && shouldShowBluetoothTip(state),
+    content: () => (
+      <>
+        <b>Bluetooth headphones limit audio to 24 kHz and add latency.</b> For playing, use wired
+        headphones, the iPad speaker, or a USB audio interface.
       </>
     ),
     action: { label: 'Open Settings', kind: 'openSettings' },

--- a/ui/src/components/AppBanner.tsx
+++ b/ui/src/components/AppBanner.tsx
@@ -1,5 +1,9 @@
 import React, { useCallback, useState } from 'react';
-import { shouldShowBluetoothTip, type AudioDeviceState } from '../types/audioDevice';
+import {
+  bluetoothTipHeadline,
+  shouldShowBluetoothTip,
+  type AudioDeviceState,
+} from '../types/audioDevice';
 import { IS_IOS } from '../hooks/useUiScale';
 import { AlertIcon, type AlertVariant } from './controls';
 import { BORDER, MUTED } from './theme';
@@ -190,10 +194,10 @@ const BANNER_RULES: BannerRule[] = [
     variant: 'info',
     dismissable: true,
     when: (state) => IS_IOS && shouldShowBluetoothTip(state),
-    content: () => (
+    content: (state) => (
       <>
-        <b>Bluetooth headphones limit audio to 24 kHz and add latency.</b> For playing, use wired
-        headphones, the iPad speaker, or a USB audio interface.
+        <b>{bluetoothTipHeadline(state)}</b> For playing, use wired headphones, the iPad speaker, or
+        a USB audio interface.
       </>
     ),
     action: { label: 'Open Settings', kind: 'openSettings' },

--- a/ui/src/components/SystemSettings.tsx
+++ b/ui/src/components/SystemSettings.tsx
@@ -575,7 +575,18 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({ device }) => {
               ariaLabel="Sample rate"
             />
             {rateCaption(state) && <p style={captionStyle}>{rateCaption(state)}</p>}
-            <InlineBannerAlert id="rate-not-48k" state={state} />
+            {/* iOS: the Bluetooth route is why the rate list is short and the
+                rate is low, so it goes first and the generic note is dropped
+                when it fires (one explanation, not two). */}
+            <InlineBannerAlert id="bluetooth-route" state={state} />
+            <InlineBannerAlert
+              id="rate-not-48k"
+              state={state}
+              show={
+                !bannerRuleById['bluetooth-route'].when(state) &&
+                bannerRuleById['rate-not-48k'].when(state)
+              }
+            />
           </FieldRow>
         )}
 

--- a/ui/src/components/SystemSettings.tsx
+++ b/ui/src/components/SystemSettings.tsx
@@ -583,7 +583,7 @@ export const SystemSettings: React.FC<SystemSettingsProps> = ({ device }) => {
               id="rate-not-48k"
               state={state}
               show={
-                !bannerRuleById['bluetooth-route'].when(state) &&
+                !bannerRuleById['bluetooth-route']?.when(state) &&
                 bannerRuleById['rate-not-48k'].when(state)
               }
             />

--- a/ui/src/hooks/useUiScale.ts
+++ b/ui/src/hooks/useUiScale.ts
@@ -17,6 +17,23 @@ let committedDesignHeight = DESIGN_HEIGHT;
 let pendingDesignHeight: number | undefined;
 let pendingTimer: number | undefined;
 
+/**
+ * True in the iOS app, where native injects the flag at document start (see
+ * the JUCE_IOS user script in EditorWebViewSetup.cpp). iOS is the only build
+ * whose window is a fixed, full-screen box: there is no corner drag, no host
+ * resize request, and the screen's aspect (4:3 on every iPad) is nothing like
+ * the design box's 1024:578. Everywhere else this is false and the code below
+ * behaves exactly as it always has.
+ */
+export const IS_IOS =
+  (window as unknown as { __T3K_PLATFORM__?: string }).__T3K_PLATFORM__ === 'ios';
+
+// Stylesheet hook for the iOS-only rules in index.css (the 44 pt touch floor
+// and the safe-area padding). Set here rather than in a component so it is on
+// the element before the first paint, and set only on iOS, so every other
+// build's <html> carries no extra class.
+if (IS_IOS && typeof document !== 'undefined') document.documentElement.classList.add('t3k-ios');
+
 /** Largest scale at which a 1024 x designHeight box fits the viewport. The
  * floor covers 0-sized viewports during boot/teardown: pointer math divides
  * by the scale, so it must never be 0. */

--- a/ui/src/types/audioDevice.ts
+++ b/ui/src/types/audioDevice.ts
@@ -50,7 +50,22 @@ export interface AudioDeviceState {
   midiInputs: MidiInputDevice[];
   /** OS Bluetooth MIDI pairing dialog exists (macOS). */
   btMidiAvailable: boolean;
+  /** iOS only: the audio session's current route is Bluetooth (HFP, A2DP or
+      LE). Always false on desktop, where the OS does not force a route on
+      us. Drives the Bluetooth tip (see shouldShowBluetoothTip). */
+  bluetoothRoute: boolean;
 }
+
+/**
+ * Should the Bluetooth tip show? Pure, so it can be tested without React.
+ *
+ * Two ways in: the route itself is Bluetooth, or the session came up below
+ * 44.1 kHz, which on iOS effectively only happens on a headset (HFP) route
+ * capped at 16 or 24 kHz. The rate arm is the safety net for a route the
+ * port-type list does not name; the caller gates the whole thing to iOS.
+ */
+export const shouldShowBluetoothTip = (state: AudioDeviceState): boolean =>
+  state.deviceOpen && (state.bluetoothRoute || (state.sampleRate > 0 && state.sampleRate < 44100));
 
 export interface MidiInputDevice {
   /** OS device identifier (stable key for enable/disable). */

--- a/ui/src/types/audioDevice.ts
+++ b/ui/src/types/audioDevice.ts
@@ -67,6 +67,22 @@ export interface AudioDeviceState {
 export const shouldShowBluetoothTip = (state: AudioDeviceState): boolean =>
   state.deviceOpen && (state.bluetoothRoute || (state.sampleRate > 0 && state.sampleRate < 44100));
 
+/**
+ * The headline the tip can stand behind. Only a route the session reports as
+ * Bluetooth gets named as Bluetooth; a low rate on any other route (a USB
+ * interface opened at 32 kHz, say) is described as what it is, a low rate,
+ * so the banner never claims a cause it cannot see. Pure, tested.
+ */
+export const bluetoothTipHeadline = (state: AudioDeviceState): string => {
+  const kHz = `${Math.round(state.sampleRate / 1000)} kHz`;
+  const capped = state.sampleRate > 0 && state.sampleRate < 44100;
+  if (state.bluetoothRoute)
+    return capped
+      ? `Bluetooth headphones are limiting audio to ${kHz} and add latency.`
+      : 'Bluetooth headphones add latency.';
+  return `This audio route is running at ${kHz}, which limits fidelity and adds latency.`;
+};
+
 export interface MidiInputDevice {
   /** OS device identifier (stable key for enable/disable). */
   id: string;

--- a/ui/test/bluetoothTip.test.ts
+++ b/ui/test/bluetoothTip.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The pure predicate behind the iOS Bluetooth tip.
+ *
+ * The ui has no test runner, so this is a plain `node --test` file; Node
+ * strips the TypeScript types on import. Run it with:
+ *
+ *   node --test ui/test/
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { shouldShowBluetoothTip, type AudioDeviceState } from '../src/types/audioDevice.ts';
+
+/** A healthy USB-interface snapshot: open, 48 kHz, no Bluetooth. Only the
+    three fields the predicate reads matter. */
+const base = {
+  deviceOpen: true,
+  sampleRate: 48000,
+  bluetoothRoute: false,
+} as unknown as AudioDeviceState;
+
+const withState = (over: Partial<AudioDeviceState>) =>
+  shouldShowBluetoothTip({ ...base, ...over } as AudioDeviceState);
+
+test('quiet on a normal 48 kHz route', () => {
+  assert.equal(withState({}), false);
+});
+
+test('fires on a Bluetooth route even at a normal rate (A2DP output)', () => {
+  assert.equal(withState({ bluetoothRoute: true }), true);
+});
+
+test('fires on the 24 kHz session the owner saw, route flag or not', () => {
+  assert.equal(withState({ sampleRate: 24000 }), true);
+  assert.equal(withState({ sampleRate: 24000, bluetoothRoute: true }), true);
+});
+
+test('44.1 kHz is a normal rate, not a capped one', () => {
+  assert.equal(withState({ sampleRate: 44100 }), false);
+});
+
+test('stays quiet while no device is open (0 Hz is not a capped rate)', () => {
+  assert.equal(withState({ deviceOpen: false, sampleRate: 0 }), false);
+  assert.equal(withState({ deviceOpen: false, bluetoothRoute: true }), false);
+  assert.equal(withState({ sampleRate: 0 }), false);
+});

--- a/ui/test/bluetoothTip.test.ts
+++ b/ui/test/bluetoothTip.test.ts
@@ -9,7 +9,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { shouldShowBluetoothTip, type AudioDeviceState } from '../src/types/audioDevice.ts';
+import {
+  bluetoothTipHeadline,
+  shouldShowBluetoothTip,
+  type AudioDeviceState,
+} from '../src/types/audioDevice.ts';
 
 /** A healthy USB-interface snapshot: open, 48 kHz, no Bluetooth. Only the
     three fields the predicate reads matter. */
@@ -43,4 +47,17 @@ test('stays quiet while no device is open (0 Hz is not a capped rate)', () => {
   assert.equal(withState({ deviceOpen: false, sampleRate: 0 }), false);
   assert.equal(withState({ deviceOpen: false, bluetoothRoute: true }), false);
   assert.equal(withState({ sampleRate: 0 }), false);
+});
+
+test('names Bluetooth only when the route says so', () => {
+  const headline = (over: Partial<AudioDeviceState>) =>
+    bluetoothTipHeadline({ ...base, ...over } as AudioDeviceState);
+  // A2DP at a normal rate: latency is the only true claim.
+  assert.equal(headline({ bluetoothRoute: true }), 'Bluetooth headphones add latency.');
+  // HFP: the cap is named with the rate the session actually has, not a fixed 24.
+  assert.match(headline({ sampleRate: 24000, bluetoothRoute: true }), /limiting audio to 24 kHz/);
+  assert.match(headline({ sampleRate: 16000, bluetoothRoute: true }), /limiting audio to 16 kHz/);
+  // A USB interface at 32 kHz is a low rate, not Bluetooth.
+  assert.doesNotMatch(headline({ sampleRate: 32000 }), /Bluetooth/);
+  assert.match(headline({ sampleRate: 32000 }), /32 kHz/);
 });

--- a/ui/test/bluetoothTip.test.ts
+++ b/ui/test/bluetoothTip.test.ts
@@ -34,7 +34,7 @@ test('fires on a Bluetooth route even at a normal rate (A2DP output)', () => {
   assert.equal(withState({ bluetoothRoute: true }), true);
 });
 
-test('fires on the 24 kHz session the owner saw, route flag or not', () => {
+test('fires on a 24 kHz HFP session, route flag or not', () => {
   assert.equal(withState({ sampleRate: 24000 }), true);
   assert.equal(withState({ sampleRate: 24000, bluetoothRoute: true }), true);
 });
@@ -59,5 +59,8 @@ test('names Bluetooth only when the route says so', () => {
   assert.match(headline({ sampleRate: 16000, bluetoothRoute: true }), /limiting audio to 16 kHz/);
   // A USB interface at 32 kHz is a low rate, not Bluetooth.
   assert.doesNotMatch(headline({ sampleRate: 32000 }), /Bluetooth/);
-  assert.match(headline({ sampleRate: 32000 }), /32 kHz/);
+  assert.equal(
+    headline({ sampleRate: 32000 }),
+    'This audio route is running at 32 kHz, which limits fidelity and adds latency.'
+  );
 });


### PR DESCRIPTION
## Summary

Refs #55. Third iOS PR, on main with #60, #95 and #104 in. Independent of the touch PR (#108) apart from one shared commit (see below).

Two things, one of which is a fix to main as it stands today:

**1. `setMode:` alone clears the category options (fix to #95).** Measured on an iPad Pro (iPadOS 26) and posted on #95: after JUCE opens the device with options 0x6d, the bare `setMode:Measurement` that `setAudioPreprocessingEnabled(false)` performs leaves the session with options 0x1 (MixWithOthers only). A2DP, AirPlay and DefaultToSpeaker are gone, so `PlayAndRecord` no longer offers Bluetooth headphones as an output. The first TestFlight build would ship with that.

The fix is one call instead of two: `setCategory:mode:options:` with JUCE's own options read from the live session minus `AllowBluetoothHFP`, and Measurement mode. `applyRawInputMode` (the #95 entry point, called from the constructor and the change callback) now calls `IosAudioRoute::configureSession()`, which is that single call. It returns early when the session already has the wanted options and mode, which is what stops the CategoryChange notification our own call raises from looping. Measured after the change: options 0x69 and Measurement, held across unplugging a USB interface (built-in mic at 48 kHz, AirPods as A2DP output) and plugging it back in.

**2. Stop asking for HFP, and say so in the UI.** With the HFP option set, iOS routes both directions of a Bluetooth headset through the headset profile and the whole session drops to 16 or 24 kHz. Dropping the option keeps A2DP output (headphones still work for listening) and moves the input to the built-in mic or the USB interface. When the session is on a Bluetooth route, or comes up below 44.1 kHz, an info banner and an inline note in Settings say so and point at wired headphones, the speaker or a USB interface. Pure predicate with a node test.

Commits:

- `feat(ios)`: the platform flag, C++ to web UI (`window.__T3K_PLATFORM__`, `IS_IOS`). Shared with #108; whichever lands second rebases it away. The `t3k-ios` class it adds to `<html>` has no rules in this PR.
- `feat(ios)`: `IosAudioRoute` (`#if JUCE_IOS`, header-only no-op elsewhere), `bluetoothRoute` in the audio device state (always `false` on desktop), banner and Settings note gated on `IS_IOS`.
- `docs(ios)`: the rate cap, what ships for it, and what does not.
- `fix(ios)`: from an independent review: the banner names Bluetooth only when the route is Bluetooth and the cap only with the rate the session has; the ui test script runs in Build Plugin, which moves to Node 24 (`node --test` with a glob and type stripping); lint and Prettier cover `ui/test`.
- `fix(ios)`: the one-call `setCategory:mode:options:` described above, replacing the earlier two-step order we agreed on #60.
- `fix(ios)`: review follow-ups (options read from the session rather than rebuilt, one immediate retry, Playback category left alone, comment on the CategoryChange loop, doc).

Desktop: every C++ hunk is under `#if JUCE_IOS` or an inline no-op; the banner rule's `when` is `IS_IOS && ...`; the Settings `show` expression reduces to the previous rule on desktop. One new JSON field the desktop UI never reads.

Not in this PR: the touch adaptation (#108); Bluetooth MIDI (unchanged); a latency figure in the UI.

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab.

- [x] DSP: N/A, no DSP change
- [x] UI: `cd ui && npm run lint && npm run test && npm run build` on `1c97284`
- [ ] Host validators: N/A (no processor, editor or wrapper change on desktop)
- [x] Host smoke: macOS Standalone rebuilt; iOS Simulator Release build; **Build Plugin** green on macOS Universal, Windows x64, Linux x64, Linux aarch64 and iOS Simulator (fork run `https://github.com/brunofgsaraiva/tone3000-plugin/actions/runs/34385227779`)
- [x] Device, iPad Pro 12.9 (iPadOS 26), AirPods Pro and a Scarlett 2i2 on USB, session options and mode logged around each call: options 0x69 and Measurement mode held through Scarlett in, AirPods as output, Scarlett out (built-in mic at 48 kHz, AirPods A2DP output, no app restart), Scarlett back in (44.1 or 48 kHz as the interface reports). Guitar through the Scarlett with three NAM models loaded: no clicks or dropouts, audio kept running with the iPad locked.

No DSP behaviour change.

## Compatibility

- [x] AU parameter version hints in `Processor.cpp` are not reused or renumbered (file untouched)
- [x] Preset format unchanged
- [x] Desktop installer and plugin formats unchanged

## Questions for maintainers

1. If you would rather take the #95 fix on its own first, say so and I will split the `setCategory:mode:options:` commit into a small PR and rebase this one on it.
2. Dropping HFP is a product decision (a Bluetooth headset microphone stops being an input). It is the right one for a guitar amp; say so if you want it behind a setting.
3. Node 24 in the workflow: fine, or would you rather pin 22 and pass `--experimental-strip-types` to the test script?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
