### PR TITLE
feat: IR envelope shaping — Predelay, Length/Decay, and a drag-on-graph editor

### DIFF
--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -306,6 +306,8 @@ target_sources(${PROJECT_NAME}
     PRIVATE
         include/BlockEq.h
         src/BlockEq.cpp
+        include/BlockPredelay.h
+        src/BlockPredelay.cpp
         include/BlockSpectrum.h
         src/BlockSpectrum.cpp
         include/ChainBlock.h

--- a/plugin/include/BlockPredelay.h
+++ b/plugin/include/BlockPredelay.h
@@ -1,0 +1,69 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <array>
+#include <vector>
+
+/**
+ * Predelay for IR blocks: delays the wet signal before it reaches the
+ * convolver, so the IR's tail starts later without touching the loaded
+ * impulse response itself (padding the IR's own buffer would force a full
+ * convolver rebuild — with its ~150ms silent install fade — on every live
+ * change, and would inflate the uniform engine's kernel-length-bound CPU
+ * cost and its short/long classification).
+ *
+ * Always runs at kChainBaseSampleRate, called from inside the block's
+ * base-rate island (see ChainOversampler) right before
+ * juce::dsp::Convolution::process() — the same rate convolution itself
+ * always runs at, regardless of the chain's oversampling factor.
+ *
+ * Threading model, mirrors BlockEq: prepare()/setDelayMs() run on the
+ * message thread (under chainMutex); process() runs on the audio thread
+ * and performs zero allocation. The ring buffer is sized once in
+ * prepare() for the maximum delay (kMaxDelayMs) and never resized.
+ *
+ * Click-free live changes: setDelayMs() ramps a *smoothed delay time*
+ * (LinearSmoothedValue<float>, in fractional samples, over kRampSeconds)
+ * rather than jumping the read offset directly, and process() reads the
+ * ring buffer at that fractional position with linear interpolation every
+ * sample — so the delay itself glides continuously and there is no
+ * stepping artifact mid-ramp. A large/fast change is still audible as a
+ * brief pitch/doppler bend (inherent to any live-changing delay line, not
+ * a bug) rather than a click. kRampSeconds (10ms) was picked by ear,
+ * A/B-ing fast slider drags and large jumps against the alternative
+ * (padding the loaded IR, rejected — see the note above on why).
+ *
+ * Structural changes (block (re)prepare, state restore) go through
+ * prepare()'s initialMs argument and snap directly, no ramp: there is no
+ * live signal continuity to protect at that point, and ramping in from 0
+ * on every host resample/oversampling change would itself be audible.
+ */
+class BlockPredelay {
+public:
+  static constexpr float kMaxDelayMs = 1000.0f;
+  // Live-change ramp time, picked by ear (see class comment).
+  static constexpr float kRampSeconds = 0.01f;
+
+  /** Message thread. (Re)allocates the ring buffer for kMaxDelayMs at
+      `sampleRate` and snaps directly to `initialMs` (no ramp, no
+      allocation on any later call). */
+  void prepare(double sampleRate, float initialMs);
+
+  /** Message thread (under chainMutex). Ramps toward `ms` over
+      kRampSeconds; clamped to [0, kMaxDelayMs]. */
+  void setDelayMs(float ms);
+
+  /** Audio thread. Processes up to 2 channels in place; zero allocation.
+      Always call for a loaded IR block (no flat-skip/isActive() gate):
+      the per-sample cost is one ring write + one linearly-interpolated
+      read per channel, trivial next to the convolution it feeds, and
+      skipping it based on the target being 0 would risk truncating an
+      in-flight downward ramp's still-delayed tail. */
+  void process(juce::AudioBuffer<float>& buffer);
+
+private:
+  std::array<std::vector<float>, 2> ring;
+  size_t capacity{0};
+  size_t writePos{0};
+  double sampleRate{48000.0};
+  juce::LinearSmoothedValue<float> delaySamplesSmoothed;
+};

--- a/plugin/include/BlockPredelay.h
+++ b/plugin/include/BlockPredelay.h
@@ -28,9 +28,10 @@
  * sample — so the delay itself glides continuously and there is no
  * stepping artifact mid-ramp. A large/fast change is still audible as a
  * brief pitch/doppler bend (inherent to any live-changing delay line, not
- * a bug) rather than a click. kRampSeconds (10ms) was picked by ear,
- * A/B-ing fast slider drags and large jumps against the alternative
- * (padding the loaded IR, rejected — see the note above on why).
+ * a bug) rather than a click. kRampSeconds was picked by ear, A/B-ing fast
+ * slider drags and large jumps against the alternative (padding the loaded
+ * IR, rejected — see the note above on why); 10ms proved too short in
+ * practice (audible noise on UI knob drags) and was widened to 300ms.
  *
  * Structural changes (block (re)prepare, state restore) go through
  * prepare()'s initialMs argument and snap directly, no ramp: there is no
@@ -41,7 +42,7 @@ class BlockPredelay {
 public:
   static constexpr float kMaxDelayMs = 1000.0f;
   // Live-change ramp time, picked by ear (see class comment).
-  static constexpr float kRampSeconds = 0.01f;
+  static constexpr float kRampSeconds = 0.3f;
 
   /** Message thread. (Re)allocates the ring buffer for kMaxDelayMs at
       `sampleRate` and snaps directly to `initialMs` (no ramp, no

--- a/plugin/include/ChainBlock.h
+++ b/plugin/include/ChainBlock.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include "BlockEq.h"
 #include "BlockPredelay.h"
@@ -172,6 +173,22 @@ struct ChainBlock {
   juce::LinearSmoothedValue<float> irNormalizationSmoother;
   float irNormalizationGainLinear{1.0f};
 
+  // Untouched, file-rate copy of the loaded IR (source of truth for the
+  // waveform display and future Length/Decay/Curve editing) plus a
+  // downsampled { min, max } per column for that display. Runtime-only:
+  // never persisted, rebuilt from the cached model bytes on restore the
+  // same way convolverMono itself is. Cleared when the block's IR is
+  // swapped/removed (see ProcessorModelLoader.cpp's apply step).
+  juce::AudioBuffer<float> irRawSamples;
+  double irRawSampleRate{0.0};
+  // Detected end of audible content within irRawSamples (file-rate samples):
+  // -60 dB relative to peak, scanned backward in ~2ms pooled-RMS windows,
+  // plus a margin (see computeIrContentLengthSamples). Single source of
+  // truth for the waveform display's auto-fit trim and the length label -
+  // shipped to the UI as irContentLengthMs (ms, at irRawSampleRate).
+  int irContentLengthSamples{0};
+  std::vector<std::pair<float, float>> irWaveformPeaks;
+
   // Predelay: delays the wet signal before it enters the convolver (see
   // BlockPredelay). Runs inside irBaseRateIsland, always at the base rate.
   // predelayNormalized is the persisted 0..1 knob value (same convention as
@@ -179,6 +196,58 @@ struct ChainBlock {
   // setDelayMs(predelayNormalized * BlockPredelay::kMaxDelayMs).
   BlockPredelay predelay;
   float predelayNormalized{0.0f};
+
+  // IR envelope: a 2-segment Attack/Decay shape (Space Designer-style) over
+  // the loaded IR, truncating it (+ short fade-out) and applying a gain
+  // envelope in one pass - see TONE3000Processor::prepareIrShapeRebuild for
+  // the exact formula. Rebuilds the convolver engine off-thread rather than
+  // processing in real time (see rebuildIrShapeInBackground) - unlike
+  // Predelay, this edits what the convolver *is*, not a real-time DSP stage.
+  //
+  // Init Level is the level at sample 0 (the origin point, not part of
+  // either segment). The Attack segment runs from there up to unity/0dB -
+  // pinned, not a knob: standard AD-envelope semantics (Attack always
+  // reaches full level; only Decay's target level is adjustable) - then the
+  // Decay segment continues from that peak to the truncated content's end
+  // (Decay Length, Decay Level). Both adjustable levels are unipolar
+  // attenuation-only (0..1, 1.0 = unity/0dB, 0.0 = genuine silence - see
+  // prepareIrShapeRebuild's levelToDb for why that needs a small
+  // float-safety floor internally but still lands on exact silence at the
+  // sample the knob targets). Each segment has its own continuous curve
+  // control (0.5 default = linear-in-dB/"exponential", sweeping
+  // steeper-front-loaded below and back-loaded above - same kCurveMax
+  // power-curve formula Length+Decay used before this became two segments).
+  //
+  // Length semantics: decayLengthNormalized is the TOTAL truncated length -
+  // the real "End" position, exactly the old standalone Length knob's own
+  // convention: a fraction of the block's full frozen detected content
+  // (irContentLengthSamples, load-time). attackLengthNormalized is NOT an
+  // independent segment length - it's a fraction *of that total*, marking
+  // where the peak (the Attack/Decay boundary) sits within it, so it's
+  // naturally bounded to [0, the total] by construction (a fraction of a
+  // fraction), no separate clamp/edge-case needed, and dragging Attack
+  // Length alone can never change the total window length - only Decay
+  // Length does that. Defaults (attackLength 0.0, decayLength 1.0, every
+  // level 1.0) reconstruct the pre-segment behavior exactly: no attack ramp,
+  // decay spans the full content, flat/unity envelope - a genuine no-op,
+  // matching the old lengthNormalized=1.0/level=unity defaults.
+  // irIsLong/irNumChannels and irRawSamples/irContentLengthSamples/
+  // irWaveformPeaks never change from an envelope edit - only the live
+  // convolverMono/convolverStereo and irLengthBaseSamples do; the waveform
+  // display's fixed window and the -18dB cab pad / default mix stay exactly
+  // what they were at load.
+  float initLevelNormalized{1.0f};
+  float attackLengthNormalized{0.0f};
+  float attackCurveNormalized{0.5f};
+  float decayLengthNormalized{1.0f};
+  float decayLevelNormalized{1.0f};
+  float decayCurveNormalized{0.5f};
+
+  // Bumped by setBlockIrDecay, captured by rebuildIrShapeInBackground's
+  // caller as the generation it's targeting: a "latest wins" supersede
+  // guard, since a rebuild must read *all seven* shaping params fresh off
+  // the block rather than trusting a single stashed target value.
+  std::atomic<int> irShapingGeneration{0};
 
   // Per-block loudness normalization toggle, NAM only (off = the capture's
   // true level, which is real information; IR normalization is always on

--- a/plugin/include/ChainBlock.h
+++ b/plugin/include/ChainBlock.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include "BlockEq.h"
+#include "BlockPredelay.h"
 #include "BlockSpectrum.h"
 #include "ChainOversampler.h"
 #include "NamEngine.h"
@@ -170,6 +171,14 @@ struct ChainBlock {
   bool irIsLong{false};
   juce::LinearSmoothedValue<float> irNormalizationSmoother;
   float irNormalizationGainLinear{1.0f};
+
+  // Predelay: delays the wet signal before it enters the convolver (see
+  // BlockPredelay). Runs inside irBaseRateIsland, always at the base rate.
+  // predelayNormalized is the persisted 0..1 knob value (same convention as
+  // mixNormalized/inputGainNormalized); the engine is driven in real ms via
+  // setDelayMs(predelayNormalized * BlockPredelay::kMaxDelayMs).
+  BlockPredelay predelay;
+  float predelayNormalized{0.0f};
 
   // Per-block loudness normalization toggle, NAM only (off = the capture's
   // true level, which is real information; IR normalization is always on

--- a/plugin/include/Processor.h
+++ b/plugin/include/Processor.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 #include "NAM/dsp.h"
 #include "NAM/get_dsp.h"
@@ -205,8 +206,15 @@ public:
   void loadToneInBackground(const std::string& blockId, int firstModelId,
                             const juce::String& modelUrl, const juce::String& modelName,
                             ChainBlockType type);
-  void switchModelInBackground(const std::string& blockId, int modelId, 
+  void switchModelInBackground(const std::string& blockId, int modelId,
                                const juce::String& modelUrl, const juce::String& modelName);
+  // Rebuilds an already-loaded IR block's convolver(s) to reflect its
+  // current envelope knob values (see setBlockIrDecay). `targetGeneration`
+  // is the ChainBlock::irShapingGeneration this job was queued for; it reads
+  // all seven shaping params fresh off the block rather than trusting a
+  // single stashed target. No fetch/prepare-from-file: works entirely from
+  // the block's own ChainBlock::irRawSamples, already in memory.
+  void rebuildIrShapeInBackground(const std::string& blockId, int targetGeneration);
 
   // Chain state for the UI. `knownRevision` is the last revision the caller
   // saw (-1 for "give me everything"); when the chain hasn't changed since,
@@ -235,6 +243,43 @@ public:
   // thread off the lock while the fade holds). Undoable; no-op sets never
   // dip the audio.
   bool setBlockSlimSize(const std::string& blockId, double slimSize);
+
+  // Per-block IR envelope: a 2-segment Attack/Decay shape (Space
+  // Designer-style) over the block's frozen, load-time detected content
+  // (ChainBlock::irContentLengthSamples). Not routed through setBlockParam:
+  // unlike its continuous params (real-time smoothers), this edits what the
+  // convolver *is* - a fresh engine is built off-thread from the block's
+  // already-loaded raw samples (rebuildIrShapeInBackground) and spliced in
+  // with the same wet-mute fade an engine swap uses, never touching
+  // irIsLong/irRawSamples/irWaveformPeaks (the waveform display's fixed
+  // window and the -18dB cab pad / default mix stay exactly what they were
+  // at load).
+  //
+  // `initLevelNormalized` is the level at sample 0 (the origin, not part of
+  // either segment). `attackLengthNormalized`/`attackCurveNormalized`
+  // define the Attack segment (0 -> unity/0dB - Attack's peak is pinned at
+  // unity, not adjustable: standard AD-envelope semantics);
+  // `decayLengthNormalized`/`decayLevelNormalized`/`decayCurveNormalized`
+  // continue from that peak to the truncated content's end. Both adjustable
+  // levels are normalized 0..1, unipolar attenuation-only (1.0 = unity/0dB,
+  // 0.0 = genuine silence - see prepareIrShapeRebuild's levelToDb). Every
+  // curve is normalized 0..1, 0.5 = linear-in-dB ("exponential" decay,
+  // already natural-sounding), below that even steeper/more front-loaded,
+  // above that back-loaded (holds, then drops) - see prepareIrShapeRebuild's
+  // exact formula. `decayLengthNormalized` is the TOTAL truncated length - a
+  // fraction of the full detected content, the real "End" position;
+  // `attackLengthNormalized` is a fraction *of that total*, marking where
+  // the peak sits within it - naturally bounded to [0, the total] by
+  // construction, no clamp/edge-case needed, and dragging Attack Length
+  // alone can never change the total window length. Undoable, coalesced
+  // like a knob drag (bumps ChainBlock::irShapingGeneration and queues
+  // rebuildIrShapeInBackground, which reads all six fresh); every value
+  // arrives together in one call, like setBlockEqBand's whole-band updates,
+  // so a drag on one knob can't clobber the others' in-flight values.
+  bool setBlockIrDecay(const std::string& blockId, double initLevelNormalized,
+                       double attackLengthNormalized, double attackCurveNormalized,
+                       double decayLengthNormalized, double decayLevelNormalized,
+                       double decayCurveNormalized);
 
   // Default NAM A2 size for newly added blocks (machine-wide user setting,
   // like multi-core), in the same slimmable-size domain. Existing blocks
@@ -286,6 +331,13 @@ public:
   juce::var getBlockSpectrum(const std::string& blockId);
   // Editor teardown: the webview can't send per-block disables while dying.
   void disableAllBlockSpectrums();
+
+  // Static IR waveform for the block card display (IR blocks only): downsampled
+  // { mins: number[], maxs: number[] } peaks per column (see
+  // ChainBlock::irWaveformPeaks). Fetched once when a block finishes loading,
+  // not part of the polled getChainState payload (the data is static per
+  // load). Returns a void var when the block isn't a loaded IR.
+  juce::var getIrWaveform(const std::string& blockId);
 
   // Stereo mode: two independent Left/Right chains.
   void setStereoMode(bool enabled);
@@ -438,10 +490,32 @@ private:
   using Lane = std::vector<std::unique_ptr<ChainBlock>>;
 
   // Helper methods
-  // Attenuation-only unit-energy gain for an IR file, matched to what the
-  // convolver actually runs (rate-corrected, same length cap). `maxIrFileSamples`
-  // is in the file's own sample rate, like the cap passed to loadImpulseResponse.
-  float computeIrNormalizationGain(const juce::File& irFile, size_t maxIrFileSamples);
+  // Attenuation-only unit-energy gain for an IR's raw samples, matched to
+  // what the convolver actually runs (rate-corrected). Takes the already-read
+  // buffer (see prepareBlockModelOffThread) rather than reopening the file:
+  // one read serves normalization, the display waveform, and the stored
+  // ChainBlock::irRawSamples copy.
+  static float computeIrNormalizationGain(const juce::AudioBuffer<float>& samples,
+                                          double fileSampleRate);
+  // Where the IR's audible content ends: -60 dB relative to peak, scanned
+  // backward in ~2ms pooled-RMS windows, plus a margin (5ms floor or 10% of
+  // the detected content, whichever is larger). Single source of truth for
+  // both the waveform display's auto-fit trim and the length label -
+  // computed once at load, in file-rate samples.
+  static int computeIrContentLengthSamples(const juce::AudioBuffer<float>& samples,
+                                           double sampleRate);
+  // Downsampled { min, max } per column across the first `contentLengthSamples`
+  // of the buffer (all channels combined, mono-ish display, not a true stereo
+  // waveform) - the source data for the block card's static waveform view.
+  static std::vector<std::pair<float, float>> computeIrWaveformPeaks(
+      const juce::AudioBuffer<float>& samples, int numColumns, int contentLengthSamples);
+  // Runs silence through a freshly loaded+prepared convolver until its
+  // internal ~50ms install crossfade has provably elapsed, so it goes live
+  // deterministically full-wet instead of splicing in a live dry-to-wet
+  // fade (see the call sites: the initial IR load, and
+  // rebuildIrShapeInBackground's in-place rebuild).
+  static void elapseConvolverInstallFade(juce::dsp::Convolution& convolver,
+                                         const juce::dsp::ProcessSpec& spec);
   juce::AudioProcessorValueTreeState::ParameterLayout createParameterLayout();
   
   // Tone loading helpers
@@ -494,6 +568,15 @@ private:
     int irLengthBaseSamples = 0;  // base-rate kernel length (tail reporting)
     bool irIsLong = false;        // short/long classification (see ChainBlock.h)
     float irNormalizationGainLinear = 1.0f;
+    // Untouched, file-rate copy: source of truth for the waveform display
+    // and Length/Decay editing. Runtime-only (see ChainBlock).
+    juce::AudioBuffer<float> irRawSamples;
+    double irRawSampleRate = 0.0;
+    // Detected end of audible content (file-rate samples), from
+    // computeIrContentLengthSamples; see ChainBlock::irContentLengthSamples.
+    int irContentLengthSamples = 0;
+    // Downsampled { min, max } per column for the static waveform display.
+    std::vector<std::pair<float, float>> irWaveformPeaks;
   };
 
   /** CPU/file heavy; call without holding `chainMutex`. NAM engines come out
@@ -502,6 +585,43 @@ private:
       lock). */
   PreparedBlockModel prepareBlockModelOffThread(ChainBlockType type, const std::vector<uint8_t>& modelData,
                                                 const juce::String& filename, double namSlimSize);
+
+  struct PreparedIrShapeRebuild {
+    bool success = false;
+    std::unique_ptr<juce::dsp::Convolution> convolverMono;
+    std::unique_ptr<juce::dsp::Convolution> convolverStereo;
+    int irLengthBaseSamples = 0;  // base-rate kernel length (tail reporting)
+  };
+
+  /** CPU heavy (builds fresh convolver engine(s)); call without holding
+      `chainMutex`. Truncates `rawSamples` to `decayLengthNormalized`'s
+      fraction of `origContentLengthSamples` (the block's frozen, load-time
+      detected length - never re-measured here; this is the TOTAL truncated
+      length, the real "End" position), with `attackLengthNormalized`
+      marking where the Attack/Decay boundary sits *within* that total (a
+      fraction of it, not an independent length - so it can never push the
+      total past what Decay Length set), applies the 2-segment Attack/Decay
+      gain envelope (`initLevelNormalized` at sample
+      0, unity/0dB at the Attack/Decay boundary - Attack's peak is pinned,
+      not adjustable - `decayLevelNormalized` at the truncated end, each
+      segment's own `attackCurveNormalized`/`decayCurveNormalized`
+      power-curve shape - see the .cpp for the exact formula) over the
+      truncated content, then a short fade-out over the cut point (always,
+      regardless of the envelope - the click-free guarantee shouldn't
+      depend on where Decay Level happens to land), and builds engine(s) of
+      the given (frozen) short/long shape. No file/network I/O: `rawSamples`
+      is the block's own already-loaded ChainBlock::irRawSamples, just a
+      copy so the caller's original stays untouched. */
+  PreparedIrShapeRebuild prepareIrShapeRebuild(const juce::AudioBuffer<float>& rawSamples,
+                                               double rawSampleRate, int origContentLengthSamples,
+                                               int irNumChannels, bool engineLongIr,
+                                               float initLevelNormalized,
+                                               float attackLengthNormalized,
+                                               float attackCurveNormalized,
+                                               float decayLengthNormalized,
+                                               float decayLevelNormalized,
+                                               float decayCurveNormalized);
+
   /** Short path under `chainMutex` only: swaps the new engines onto `block`
       and stamps `newType` (a tone swap may change the block's type; the old
       engine kept processing under the old type until this moment). The

--- a/plugin/src/BlockPredelay.cpp
+++ b/plugin/src/BlockPredelay.cpp
@@ -1,0 +1,53 @@
+#include "BlockPredelay.h"
+#include <algorithm>
+#include <cmath>
+
+void BlockPredelay::prepare(double newSampleRate, float initialMs) {
+  sampleRate = newSampleRate;
+  // +2 samples of margin over the exact max-delay sample count for the
+  // linear-interpolation lookahead tap at the boundary.
+  capacity = static_cast<size_t>(std::ceil(kMaxDelayMs * 0.001 * sampleRate)) + 2;
+  for (auto& r : ring) r.assign(capacity, 0.0f);
+  writePos = 0;
+
+  delaySamplesSmoothed.reset(sampleRate, kRampSeconds);
+  const float clampedMs = juce::jlimit(0.0f, kMaxDelayMs, initialMs);
+  delaySamplesSmoothed.setCurrentAndTargetValue(
+      static_cast<float>(clampedMs * 0.001 * sampleRate));
+}
+
+void BlockPredelay::setDelayMs(float ms) {
+  const float clampedMs = juce::jlimit(0.0f, kMaxDelayMs, ms);
+  delaySamplesSmoothed.setTargetValue(static_cast<float>(clampedMs * 0.001 * sampleRate));
+}
+
+void BlockPredelay::process(juce::AudioBuffer<float>& buffer) {
+  const int numChannels = std::min(buffer.getNumChannels(), 2);
+  const int numSamples = buffer.getNumSamples();
+  const float capacityF = static_cast<float>(capacity);
+
+  for (int i = 0; i < numSamples; ++i) {
+    const float delaySamples = delaySamplesSmoothed.getNextValue();
+
+    for (int ch = 0; ch < numChannels; ++ch) {
+      auto& r = ring[static_cast<size_t>(ch)];
+      auto* data = buffer.getWritePointer(ch);
+
+      r[writePos] = data[i];
+
+      // Fractional read position, wrapped into [0, capacity). delaySamples
+      // is always <= capacity - 2 (clamped to kMaxDelayMs in setDelayMs/
+      // prepare, capacity sized for kMaxDelayMs + margin), so a single
+      // wraparound addition is always enough — no loop/modulo needed here.
+      float readPos = static_cast<float>(writePos) - delaySamples;
+      if (readPos < 0.0f) readPos += capacityF;
+
+      const size_t idx0 = static_cast<size_t>(readPos);
+      const size_t idx1 = (idx0 + 1) % capacity;
+      const float frac = readPos - static_cast<float>(idx0);
+
+      data[i] = r[idx0] + frac * (r[idx1] - r[idx0]);
+    }
+    writePos = (writePos + 1) % capacity;
+  }
+}

--- a/plugin/src/EditorWebViewSetup.cpp
+++ b/plugin/src/EditorWebViewSetup.cpp
@@ -355,6 +355,29 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
                 args[0].toString().toStdString(), coerceDouble(args[1])));
           }))
       .withNativeFunction(
+          // (blockId, initLevelNormalized, attackLengthNormalized,
+          // attackCurveNormalized, decayLengthNormalized,
+          // decayLevelNormalized, decayCurveNormalized): the IR's 2-segment
+          // Attack/Decay envelope. Attack's peak is pinned at unity/0dB
+          // (standard AD-envelope semantics), not settable. Init/Decay
+          // Level are each 0..1, unipolar attenuation-only (1.0 = unity,
+          // 0.0 = genuine silence); every curve is 0..1, 0.5 = linear,
+          // sweeping front-loaded below / back-loaded above. Decay Length is
+          // the TOTAL truncated length (a fraction of the block's full
+          // detected content, the real "End" position); Attack Length is a
+          // fraction of that total, marking where the peak sits within it.
+          // Not a
+          // setBlockParam param because it rebuilds the convolver engine
+          // off-thread rather than driving a real-time smoother; rides
+          // getChainState as params.initLevel/attackLength/attackCurve/
+          // decayLength/decayLevel/decayCurve.
+          "setBlockIrDecay", guarded(7, false, [editor](const juce::Array<juce::var>& args) {
+            return juce::var(editor->processor.setBlockIrDecay(
+                args[0].toString().toStdString(), coerceDouble(args[1]), coerceDouble(args[2]),
+                coerceDouble(args[3]), coerceDouble(args[4]), coerceDouble(args[5]),
+                coerceDouble(args[6])));
+          }))
+      .withNativeFunction(
           // (blockId, bandIndex, { type, freqHz, gainDb, q }). Whole-band
           // updates keep drags atomic and give undo/redo a clean unit later.
           "setBlockEqBand", guarded(3, false, [editor](const juce::Array<juce::var>& args) {
@@ -392,6 +415,13 @@ juce::WebBrowserComponent::Options buildMainWebViewOptions(TONE3000Editor* edito
           // Polled ~30 Hz by an open EQ view. Returns 64 log-spaced dB bins.
           "getBlockSpectrum", guarded(1, juce::var(), [editor](const juce::Array<juce::var>& args) {
             return editor->processor.getBlockSpectrum(args[0].toString().toStdString());
+          }))
+      .withNativeFunction(
+          // Fetched once when an IR block finishes loading (static per
+          // load, not part of getChainState's polled payload). Returns
+          // { mins: number[], maxs: number[] } or null.
+          "getIrWaveform", guarded(1, juce::var(), [editor](const juce::Array<juce::var>& args) {
+            return editor->processor.getIrWaveform(args[0].toString().toStdString());
           }))
       // --- Chain state / history --------------------------------------------
       .withNativeFunction(

--- a/plugin/src/Processor.cpp
+++ b/plugin/src/Processor.cpp
@@ -454,9 +454,15 @@ void TONE3000Processor::prepareChain(std::vector<std::unique_ptr<ChainBlock>>& b
     // Every IR block keeps its base-rate island in step with the live factor
     // (bypass at ×1). Prepared even while unloaded; a later engine apply
     // re-prepares anyway, this just keeps the invariant simple.
-    if (block->type == ChainBlockType::IR)
+    if (block->type == ChainBlockType::IR) {
       block->irBaseRateIsland.prepare(chainOversampleFactor.load(),
                                       juce::jmax(1, chainBaseBlockSize()));
+      // Always at the base rate (see BlockPredelay), and snapped to the
+      // stored value, not ramped: a host resample/oversampling re-prepare
+      // has no live signal continuity to protect.
+      block->predelay.prepare(kChainBaseSampleRate,
+                              block->predelayNormalized * BlockPredelay::kMaxDelayMs);
+    }
 
     // Initialize per-block smoothers (input gain, output gain, mix, NAM
     // normalization). The RT path only ever calls setTargetValue on these;
@@ -483,12 +489,18 @@ void TONE3000Processor::prepareChain(std::vector<std::unique_ptr<ChainBlock>>& b
 // See the declaration. Both lanes are scanned regardless of stereo mode:
 // counting a disabled right lane's IR is a harmless over-report, and it means
 // stereo toggles can never truncate a host's tail rendering mid-session.
+// Predelay pushes an IR's audible tail out in time (silence, then the IR),
+// so it counts toward the reported length too, or hosts would truncate a
+// predelayed reverb tail's rendering early.
 void TONE3000Processor::refreshIrTailLength() {
   int maxSamples = 0;
   for (const auto& l : lanes)
     for (const auto& b : l)
-      if (b->type == ChainBlockType::IR && b->convolverMono != nullptr)
-        maxSamples = std::max(maxSamples, b->irLengthBaseSamples);
+      if (b->type == ChainBlockType::IR && b->convolverMono != nullptr) {
+        const int predelaySamples = static_cast<int>(std::llround(
+            b->predelayNormalized * BlockPredelay::kMaxDelayMs * 0.001 * kChainBaseSampleRate));
+        maxSamples = std::max(maxSamples, b->irLengthBaseSamples + predelaySamples);
+      }
   irTailBaseSamples.store(maxSamples);
 }
 
@@ -1190,7 +1202,15 @@ void TONE3000Processor::processChainOnBuffer(std::vector<std::unique_ptr<ChainBl
         // sound bit-identical to the non-oversampled chain.
         block->irBaseRateIsland.processBaseRateIsland(
             buffer.getArrayOfWritePointers(), numChannels, numSamples,
-            [&convolver, numChannels](float* const* baseChannels, int baseFrames) {
+            [&convolver, &predelay = block->predelay,
+             numChannels](float* const* baseChannels, int baseFrames) {
+              // Predelay runs on the wet signal here, right before the
+              // convolver, always at the base rate the island already
+              // decimated to (see BlockPredelay for why it lives here
+              // rather than padding the loaded IR itself).
+              juce::AudioBuffer<float> baseBuffer(baseChannels, numChannels, baseFrames);
+              predelay.process(baseBuffer);
+
               juce::dsp::AudioBlock<float> irBlock(baseChannels, static_cast<size_t>(numChannels),
                                                    static_cast<size_t>(baseFrames));
               convolver.process(juce::dsp::ProcessContextReplacing<float>(irBlock));

--- a/plugin/src/ProcessorChain.cpp
+++ b/plugin/src/ProcessorChain.cpp
@@ -975,11 +975,15 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
     int toneId = 0;
     int activeModelId = 0;
     bool loaded = false, loadFailed = false, modelLoading = false, irLong = false;
+    double irContentLengthMs = 0.0;
     bool hasInputDbu = false, hasOutputDbu = false;
     double inputDbu = 0.0, outputDbu = 0.0;
     bool enabled = true, normalize = true;
     double slimSize = 0.0;
     float inputGain = 0.5f, outputGain = 0.5f, mix = 1.0f, predelay = 0.0f;
+    float initLevel = 1.0f;
+    float attackLength = 0.0f, attackCurve = 0.5f;
+    float decayLength = 1.0f, decayLevel = 1.0f, decayCurve = 0.5f;
     juce::var eq;
     bool rtFailed = false;
   };
@@ -1026,6 +1030,9 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
         row.loadFailed = block->loadFailed;
         row.modelLoading = block->modelLoading;
         row.irLong = block->type == ChainBlockType::IR && block->irIsLong;
+        if (block->type == ChainBlockType::IR && block->irRawSampleRate > 0.0)
+          row.irContentLengthMs =
+              block->irContentLengthSamples / block->irRawSampleRate * 1000.0;
         // NAM calibration metadata off the loaded engine, absent when the
         // model carries none. Non-finite values never ship; the JSON bridge
         // can't carry them (and the DSP rejects them too).
@@ -1048,6 +1055,12 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
         row.outputGain = block->outputGainNormalized;
         row.mix = block->mixNormalized;
         row.predelay = block->predelayNormalized;
+        row.initLevel = block->initLevelNormalized;
+        row.attackLength = block->attackLengthNormalized;
+        row.attackCurve = block->attackCurveNormalized;
+        row.decayLength = block->decayLengthNormalized;
+        row.decayLevel = block->decayLevelNormalized;
+        row.decayCurve = block->decayCurveNormalized;
         row.eq = block->eq.toVar();
         out.push_back(std::move(row));
       }
@@ -1113,6 +1126,10 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
       // Long (reverb-like) IR: drives the UI's Mix knob default/Alt-click
       // reset and the Out knob help (long IRs carry no -18 dB pad).
       item->setProperty("irLong", row.irLong);
+      // Detected content length (ms), same window computeIrWaveformPeaks
+      // trims the waveform display to - single source of truth. 0 for NAM
+      // blocks and IR blocks not yet loaded.
+      item->setProperty("irContentLengthMs", row.irContentLengthMs);
 
       if (row.hasInputDbu)
         item->setProperty("inputLevelDbu", row.inputDbu);
@@ -1127,6 +1144,12 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
       params->setProperty("outputGain", row.outputGain);
       params->setProperty("mix", row.mix);
       params->setProperty("predelay", row.predelay);
+      params->setProperty("initLevel", row.initLevel);
+      params->setProperty("attackLength", row.attackLength);
+      params->setProperty("attackCurve", row.attackCurve);
+      params->setProperty("decayLength", row.decayLength);
+      params->setProperty("decayLevel", row.decayLevel);
+      params->setProperty("decayCurve", row.decayCurve);
       params->setProperty("eq", row.eq);
       item->setProperty("params", juce::var(params.get()));
 
@@ -1553,6 +1576,186 @@ bool TONE3000Processor::setBlockSlimSize(const std::string& blockId, double slim
   return true;
 }
 
+namespace {
+// Shared by setBlockIrDecay: bumps the block's shaping generation and queues
+// the rebuild job. Caller must already hold chainMutex.
+void queueIrShapeRebuild(TONE3000Processor& processor, ChainBlock& block,
+                         juce::ThreadPool& loadingThreadPool) {
+  const int generation = ++block.irShapingGeneration;
+  const std::string blockId = block.id;
+
+  struct RebuildIrShapeJob : public juce::ThreadPoolJob {
+    TONE3000Processor& processor;
+    std::string blockId;
+    int targetGeneration;
+
+    RebuildIrShapeJob(TONE3000Processor& p, const std::string& bid, int generation)
+        : ThreadPoolJob("Rebuild IR Shape"), processor(p), blockId(bid),
+          targetGeneration(generation) {}
+
+    JobStatus runJob() override {
+      processor.rebuildIrShapeInBackground(blockId, targetGeneration);
+      return jobHasFinished;
+    }
+  };
+  loadingThreadPool.addJob(new RebuildIrShapeJob(processor, blockId, generation), true);
+}
+}  // namespace
+
+bool TONE3000Processor::setBlockIrDecay(const std::string& blockId, double initLevelNormalized,
+                                        double attackLengthNormalized,
+                                        double attackCurveNormalized,
+                                        double decayLengthNormalized,
+                                        double decayLevelNormalized,
+                                        double decayCurveNormalized) {
+  const float clampedInitLevel = juce::jlimit(0.0f, 1.0f, static_cast<float>(initLevelNormalized));
+  const float clampedAttackLength =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(attackLengthNormalized));
+  const float clampedAttackCurve =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(attackCurveNormalized));
+  const float clampedDecayLength =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(decayLengthNormalized));
+  const float clampedDecayLevel =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(decayLevelNormalized));
+  const float clampedDecayCurve =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(decayCurveNormalized));
+
+  juce::ScopedLock lock(chainMutex);
+  ChainBlock* block = findBlockById(blockId);
+  if (block == nullptr || block->type != ChainBlockType::IR || !block->loaded) {
+    juce::Logger::writeToLog("setBlockIrDecay: not a loaded IR block: " + juce::String(blockId));
+    return false;
+  }
+  if (block->initLevelNormalized == clampedInitLevel &&
+      block->attackLengthNormalized == clampedAttackLength &&
+      block->attackCurveNormalized == clampedAttackCurve &&
+      block->decayLengthNormalized == clampedDecayLength &&
+      block->decayLevelNormalized == clampedDecayLevel &&
+      block->decayCurveNormalized == clampedDecayCurve)
+    return true;
+
+  // Coalesced like a knob drag (see setBlockParam's continuous params): the
+  // persisted values update immediately (undo/redo, presets, duplication all
+  // see them right away), the audible rebuild trails behind on the loader
+  // pool. All six arrive together (like setBlockEqBand's whole-band
+  // updates) so a drag on one can't clobber another's in-flight value.
+  pushChainHistory("param:" + juce::String(blockId) + ":decay");
+  block->initLevelNormalized = clampedInitLevel;
+  block->attackLengthNormalized = clampedAttackLength;
+  block->attackCurveNormalized = clampedAttackCurve;
+  block->decayLengthNormalized = clampedDecayLength;
+  block->decayLevelNormalized = clampedDecayLevel;
+  block->decayCurveNormalized = clampedDecayCurve;
+  deferredRevisionBump();
+  queueIrShapeRebuild(*this, *block, loadingThreadPool);
+  return true;
+}
+
+void TONE3000Processor::rebuildIrShapeInBackground(const std::string& blockId,
+                                                    int targetGeneration) {
+  juce::AudioBuffer<float> rawCopy;
+  double rawSampleRate = 0.0;
+  int origContentLengthSamples = 0;
+  int irNumChannels = 1;
+  bool engineLongIr = false;
+  float initLevelNormalized = 1.0f;
+  float attackLengthNormalized = 0.0f;
+  float attackCurveNormalized = 0.5f;
+  float decayLengthNormalized = 1.0f;
+  float decayLevelNormalized = 1.0f;
+  float decayCurveNormalized = 0.5f;
+
+  {
+    juce::ScopedLock lock(chainMutex);
+    ChainBlock* block = findBlockById(blockId);
+    if (block == nullptr || block->type != ChainBlockType::IR ||
+        block->irRawSamples.getNumSamples() <= 0) {
+      juce::Logger::writeToLog("[Background] IR shape rebuild dropped, block not found/not IR: " +
+                               juce::String(blockId));
+      return;
+    }
+    if (block->irShapingGeneration.load() != targetGeneration) {
+      // A newer drag/undo/redo already retargeted this block; that request
+      // owns it now (either already running or about to be queued).
+      juce::Logger::writeToLog("[Background] IR shape rebuild for " + juce::String(blockId) +
+                               " superseded before it started");
+      return;
+    }
+    rawCopy = block->irRawSamples;  // copy: irRawSamples must stay the untouched original
+    rawSampleRate = block->irRawSampleRate;
+    origContentLengthSamples = block->irContentLengthSamples;
+    irNumChannels = block->irNumChannels;
+    engineLongIr = block->irIsLong;  // frozen classification, never re-decided here
+    initLevelNormalized = block->initLevelNormalized;
+    attackLengthNormalized = block->attackLengthNormalized;
+    attackCurveNormalized = block->attackCurveNormalized;
+    decayLengthNormalized = block->decayLengthNormalized;
+    decayLevelNormalized = block->decayLevelNormalized;
+    decayCurveNormalized = block->decayCurveNormalized;
+  }
+
+  PreparedIrShapeRebuild prepared = prepareIrShapeRebuild(
+      rawCopy, rawSampleRate, origContentLengthSamples, irNumChannels, engineLongIr,
+      initLevelNormalized, attackLengthNormalized, attackCurveNormalized, decayLengthNormalized,
+      decayLevelNormalized, decayCurveNormalized);
+
+  // The outgoing engine keeps processing until this moment; fade it out on
+  // the audio thread first. Same shape as an engine swap (see ChainBlock.h):
+  // the wet path mutes in place, the dry share of the user's mix never gets
+  // exposed.
+  requestSwapFadeAndWait(blockId, /*muteWetOnly=*/true);
+
+  {
+    juce::ScopedLock lock(chainMutex);
+    ChainBlock* block = findBlockById(blockId);
+    if (block == nullptr) {
+      juce::Logger::writeToLog("[Background] Block removed during IR shape rebuild: " +
+                               juce::String(blockId));
+      return;
+    }
+
+    // Whatever the outcome below, this rebuild attempt is over: clear the
+    // fade flags unconditionally, before branching - mirrors
+    // applyPreparedModelToChainBlock exactly. This clear must happen on
+    // every path, success included, or swapFadePending/swapMuteWet stay
+    // stuck true and the wet term is pinned silent forever (see
+    // ChainBlock.h's swapWetMuteGain).
+    block->swapFadePending.store(false);
+    block->swapFadeDone.store(false);
+    block->swapMuteWet.store(false);
+
+    if (block->irShapingGeneration.load() != targetGeneration) {
+      // Superseded while this rebuild was running; the newer job's own
+      // requestSwapFadeAndWait re-arms the fade flags for its own attempt.
+      juce::Logger::writeToLog("[Background] IR shape rebuild for " + juce::String(blockId) +
+                               " superseded before it finished");
+      return;
+    }
+    if (!prepared.success) {
+      juce::Logger::writeToLog("[Background] IR shape rebuild failed for " +
+                               juce::String(blockId));
+      return;
+    }
+
+    std::swap(block->convolverMono, prepared.convolverMono);
+    std::swap(block->convolverStereo, prepared.convolverStereo);
+    block->irLengthBaseSamples = prepared.irLengthBaseSamples;
+    // Deliberately untouched: irIsLong, irRawSamples, irRawSampleRate,
+    // irContentLengthSamples, irWaveformPeaks, irNumChannels - the waveform
+    // display's fixed window and the block's output-pad/default-mix
+    // classification never move because of a Length or Decay edit.
+
+    refreshIrTailLength();  // irLengthBaseSamples changed; same call predelay makes
+    bumpChainRevision();
+    juce::Logger::writeToLog("[Background] IR shape rebuild applied for " +
+                             juce::String(blockId) + ": " +
+                             juce::String(prepared.irLengthBaseSamples / kChainBaseSampleRate, 2) +
+                             " s");
+  }
+  // `prepared` now holds the block's *previous* engines; destroyed here,
+  // after the lock (convolution teardown is too heavy to hold it).
+}
+
 bool TONE3000Processor::toggleBlockPower(int position, bool rightLane) {
   // The Right lane only processes in stereo mode; a mapped right-block stomp
   // outside it must not edit chain state the user can't see.
@@ -1664,6 +1867,26 @@ juce::var TONE3000Processor::getBlockSpectrum(const std::string& blockId) {
     return {};
 
   return block->spectrum.getSpectrum();
+}
+
+juce::var TONE3000Processor::getIrWaveform(const std::string& blockId) {
+  juce::ScopedLock lock(chainMutex);
+  ChainBlock* block = findBlockById(blockId);
+  if (block == nullptr || block->type != ChainBlockType::IR || block->irWaveformPeaks.empty())
+    return {};
+
+  juce::Array<juce::var> mins, maxs;
+  mins.ensureStorageAllocated(static_cast<int>(block->irWaveformPeaks.size()));
+  maxs.ensureStorageAllocated(static_cast<int>(block->irWaveformPeaks.size()));
+  for (const auto& [mn, mx] : block->irWaveformPeaks) {
+    mins.add(mn);
+    maxs.add(mx);
+  }
+
+  juce::DynamicObject::Ptr obj = new juce::DynamicObject();
+  obj->setProperty("mins", mins);
+  obj->setProperty("maxs", maxs);
+  return juce::var(obj.get());
 }
 
 void TONE3000Processor::disableAllBlockSpectrums() {

--- a/plugin/src/ProcessorChain.cpp
+++ b/plugin/src/ProcessorChain.cpp
@@ -979,7 +979,7 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
     double inputDbu = 0.0, outputDbu = 0.0;
     bool enabled = true, normalize = true;
     double slimSize = 0.0;
-    float inputGain = 0.5f, outputGain = 0.5f, mix = 1.0f;
+    float inputGain = 0.5f, outputGain = 0.5f, mix = 1.0f, predelay = 0.0f;
     juce::var eq;
     bool rtFailed = false;
   };
@@ -1047,6 +1047,7 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
         row.inputGain = block->inputGainNormalized;
         row.outputGain = block->outputGainNormalized;
         row.mix = block->mixNormalized;
+        row.predelay = block->predelayNormalized;
         row.eq = block->eq.toVar();
         out.push_back(std::move(row));
       }
@@ -1125,6 +1126,7 @@ juce::var TONE3000Processor::getChainState(int knownRevision) const {
       params->setProperty("inputGain", row.inputGain);
       params->setProperty("outputGain", row.outputGain);
       params->setProperty("mix", row.mix);
+      params->setProperty("predelay", row.predelay);
       params->setProperty("eq", row.eq);
       item->setProperty("params", juce::var(params.get()));
 
@@ -1473,7 +1475,8 @@ bool TONE3000Processor::setBlockParam(const std::string& blockId, const juce::St
     return false;
 
   // Validate before recording history, so failed calls never leave an entry.
-  const bool isContinuous = param == "inputGain" || param == "outputGain" || param == "mix";
+  const bool isContinuous =
+      param == "inputGain" || param == "outputGain" || param == "mix" || param == "predelay";
   const bool isKnown = isContinuous || param == "enabled" || param == "normalize";
   if (!isKnown) {
     DBG("setBlockParam: unknown param: " << param);
@@ -1494,6 +1497,10 @@ bool TONE3000Processor::setBlockParam(const std::string& blockId, const juce::St
     block->outputGainNormalized = juce::jlimit(0.0f, 1.0f, static_cast<float>(value));
   } else if (param == "mix") {
     block->mixNormalized = juce::jlimit(0.0f, 1.0f, static_cast<float>(value));
+  } else if (param == "predelay") {
+    block->predelayNormalized = juce::jlimit(0.0f, 1.0f, static_cast<float>(value));
+    block->predelay.setDelayMs(block->predelayNormalized * BlockPredelay::kMaxDelayMs);
+    refreshIrTailLength();
   }
 
   // Continuous drags settle into one bump after the gesture ends; discrete

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -41,6 +41,12 @@ constexpr int kShortIrMaxBaseSamples = static_cast<int>(kShortIrMaxSeconds * kCh
 // reverb head size.
 constexpr int kIrNonUniformHeadSamples = 8192;
 
+// Downsampled columns computed for the block card's static waveform display
+// (see ChainBlock::irWaveformPeaks). Comfortably above the card's actual
+// pixel width (192px design box) so higher UI scale/DPI doesn't look blocky;
+// cheap to compute either way (one-time, loader thread).
+constexpr int kIrWaveformColumns = 256;
+
 // NAM phase-interleaved oversampling eligibility (see NamEngine.h).
 // Phase interleaving is exact only for architectures whose temporal structure
 // is pure (dilated) convolution: splitting the oversampled stream into factor
@@ -283,27 +289,17 @@ juce::var localToneError(const juce::String& title, const juce::String& message)
 
 }  // namespace
 
-float TONE3000Processor::computeIrNormalizationGain(const juce::File& irFile,
-                                                    size_t maxIrFileSamples) {
-  juce::AudioFormatManager formatManager;
-  formatManager.registerBasicFormats();
-  std::unique_ptr<juce::AudioFormatReader> reader(formatManager.createReaderFor(irFile));
-
-  if (!reader || reader->lengthInSamples <= 0 || reader->numChannels <= 0) {
+float TONE3000Processor::computeIrNormalizationGain(const juce::AudioBuffer<float>& samples,
+                                                    double fileSampleRate) {
+  if (samples.getNumSamples() <= 0 || samples.getNumChannels() <= 0) {
     return 1.0f;
   }
 
-  const juce::int64 totalSamples =
-      std::min<juce::int64>(reader->lengthInSamples, static_cast<juce::int64>(maxIrFileSamples));
-  juce::AudioBuffer<float> tmp(static_cast<int>(reader->numChannels),
-                               static_cast<int>(totalSamples));
-  reader->read(&tmp, 0, static_cast<int>(totalSamples), 0, true, true);
-
   double sumSquares = 0.0;
   juce::int64 count = 0;
-  for (int ch = 0; ch < tmp.getNumChannels(); ++ch) {
-    const float* data = tmp.getReadPointer(ch);
-    for (int i = 0; i < tmp.getNumSamples(); ++i) {
+  for (int ch = 0; ch < samples.getNumChannels(); ++ch) {
+    const float* data = samples.getReadPointer(ch);
+    for (int i = 0; i < samples.getNumSamples(); ++i) {
       const float sample = data[i];
       sumSquares += static_cast<double>(sample) * static_cast<double>(sample);
       ++count;
@@ -321,8 +317,7 @@ float TONE3000Processor::computeIrNormalizationGain(const juce::File& irFile,
   // fileRate/baseRate. Fold that in so the gain matches what the engine
   // actually convolves regardless of the file's sample rate (a no-op for
   // 48 kHz files).
-  const double rateScale =
-      reader->sampleRate > 0.0 ? reader->sampleRate / kChainBaseSampleRate : 1.0;
+  const double rateScale = fileSampleRate > 0.0 ? fileSampleRate / kChainBaseSampleRate : 1.0;
   const double l2norm = std::sqrt(sumSquares * rateScale);
   if (!std::isfinite(l2norm) || l2norm <= 0.0) {
     return 1.0f;
@@ -339,6 +334,285 @@ float TONE3000Processor::computeIrNormalizationGain(const juce::File& irFile,
       juce::jlimit(juce::Decibels::decibelsToGain(-48.0), 1.0, linear);
 
   return static_cast<float>(linearClamped);
+}
+
+void TONE3000Processor::elapseConvolverInstallFade(juce::dsp::Convolution& convolver,
+                                                    const juce::dsp::ProcessSpec& spec) {
+  const int chunk = static_cast<int>(spec.maximumBlockSize);
+  juce::AudioBuffer<float> silence(static_cast<int>(spec.numChannels), chunk);
+  silence.clear();
+  // 3x JUCE's 0.05s install fade: margin over exactness, it's cheap.
+  const int warmupSamples = static_cast<int>(kChainBaseSampleRate * 0.15);
+  for (int done = 0; done < warmupSamples; done += chunk) {
+    juce::dsp::AudioBlock<float> blockRef(silence);
+    convolver.process(juce::dsp::ProcessContextReplacing<float>(blockRef));
+  }
+}
+
+int TONE3000Processor::computeIrContentLengthSamples(const juce::AudioBuffer<float>& samples,
+                                                      double sampleRate) {
+  const int numSamples = samples.getNumSamples();
+  const int numChannels = samples.getNumChannels();
+  if (numSamples <= 0 || numChannels <= 0 || sampleRate <= 0.0)
+    return numSamples;
+
+  float peakAbs = 0.0f;
+  for (int ch = 0; ch < numChannels; ++ch) {
+    const float* data = samples.getReadPointer(ch);
+    for (int i = 0; i < numSamples; ++i)
+      peakAbs = std::max(peakAbs, std::abs(data[i]));
+  }
+  const float threshold = peakAbs * juce::Decibels::decibelsToGain(-60.0f);
+  const int windowSamples = std::max(1, static_cast<int>(std::llround(sampleRate * 0.002)));
+
+  // Scan pooled-RMS windows from the end backward; contentEndSample is the
+  // end of the last (temporally, i.e. first found going backward) window
+  // whose RMS clears the threshold. Silence (or a peak of exactly zero)
+  // never clears it, so this naturally falls through to contentEndSample=0.
+  int contentEndSample = 0;
+  for (int windowEnd = numSamples; windowEnd > 0; windowEnd -= windowSamples) {
+    const int windowStart = std::max(0, windowEnd - windowSamples);
+    double sumSq = 0.0;
+    int count = 0;
+    for (int ch = 0; ch < numChannels; ++ch) {
+      const float* data = samples.getReadPointer(ch);
+      for (int i = windowStart; i < windowEnd; ++i) {
+        sumSq += static_cast<double>(data[i]) * data[i];
+        ++count;
+      }
+    }
+    const float windowRms = count > 0 ? static_cast<float>(std::sqrt(sumSq / count)) : 0.0f;
+    if (windowRms > threshold) {
+      contentEndSample = windowEnd;
+      break;
+    }
+  }
+
+  const int margin =
+      std::max(static_cast<int>(std::llround(sampleRate * 0.005)),
+               static_cast<int>(contentEndSample * 0.1));
+  return std::min(numSamples, contentEndSample + margin);
+}
+
+std::vector<std::pair<float, float>> TONE3000Processor::computeIrWaveformPeaks(
+    const juce::AudioBuffer<float>& samples, int numColumns, int contentLengthSamples) {
+  std::vector<std::pair<float, float>> peaks(
+      static_cast<size_t>(std::max(0, numColumns)), {0.0f, 0.0f});
+  const int numSamples = std::min(samples.getNumSamples(), std::max(0, contentLengthSamples));
+  const int numChannels = samples.getNumChannels();
+  if (numSamples <= 0 || numChannels <= 0 || numColumns <= 0) {
+    return peaks;
+  }
+
+  // All channels combined into one mono-ish envelope (a true stereo display
+  // is more than this static POC needs); each column covers an even slice of
+  // the buffer regardless of numColumns vs numSamples.
+  for (int col = 0; col < numColumns; ++col) {
+    const juce::int64 begin = (static_cast<juce::int64>(col) * numSamples) / numColumns;
+    const juce::int64 end = std::max<juce::int64>(
+        begin + 1, (static_cast<juce::int64>(col + 1) * numSamples) / numColumns);
+    float mn = 0.0f, mx = 0.0f;
+    for (int ch = 0; ch < numChannels; ++ch) {
+      const float* data = samples.getReadPointer(ch);
+      for (juce::int64 i = begin; i < end && i < numSamples; ++i) {
+        mn = std::min(mn, data[i]);
+        mx = std::max(mx, data[i]);
+      }
+    }
+    peaks[static_cast<size_t>(col)] = {mn, mx};
+  }
+  return peaks;
+}
+
+TONE3000Processor::PreparedIrShapeRebuild TONE3000Processor::prepareIrShapeRebuild(
+    const juce::AudioBuffer<float>& rawSamples, double rawSampleRate, int origContentLengthSamples,
+    int irNumChannels, bool engineLongIr, float initLevelNormalized,
+    float attackLengthNormalized, float attackCurveNormalized, float decayLengthNormalized,
+    float decayLevelNormalized, float decayCurveNormalized) {
+  PreparedIrShapeRebuild out;
+  const int numRawSamples = rawSamples.getNumSamples();
+  if (numRawSamples <= 0 || rawSampleRate <= 0.0 || irNumChannels <= 0)
+    return out;
+
+  // Decay Length is the TOTAL truncated length - the real "End" position,
+  // exactly the old standalone Length knob's own convention: a fraction 0..1
+  // of the block's frozen, load-time detected content (never re-measured
+  // here), floored so an extreme drag never collapses to a degenerate/empty
+  // kernel. Attack Length is NOT an independent segment length - it's a
+  // fraction 0..1 *of that total*, marking where the peak (the Attack/Decay
+  // boundary) sits within it. That makes it naturally bounded to
+  // [0, targetSamples] by construction (a fraction of a fraction), no
+  // separate clamp/remainder bookkeeping needed, and - unlike the earlier
+  // "Attack is independent, Decay is whatever's left" model - dragging
+  // Attack Length alone can never change the total window length; only
+  // Decay Length does that.
+  const int minSamples = std::max(1, static_cast<int>(std::llround(rawSampleRate * 0.005)));
+  const int maxContentSamples =
+      std::min(numRawSamples, std::max(minSamples, origContentLengthSamples));
+  const int targetSamples = juce::jlimit(
+      minSamples, maxContentSamples,
+      static_cast<int>(std::llround(juce::jmap(juce::jlimit(0.0f, 1.0f, decayLengthNormalized),
+                                                0.0f, 1.0f, static_cast<float>(minSamples),
+                                                static_cast<float>(maxContentSamples)))));
+  const int attackBoundary = juce::jlimit(
+      0, targetSamples,
+      static_cast<int>(std::llround(juce::jlimit(0.0f, 1.0f, attackLengthNormalized) *
+                                     static_cast<float>(targetSamples))));
+
+  juce::AudioBuffer<float> trimmed(irNumChannels, targetSamples);
+  for (int ch = 0; ch < irNumChannels; ++ch)
+    trimmed.copyFrom(ch, 0, rawSamples, ch, 0, targetSamples);
+
+  // Envelope: Init Level (sample 0) ramps through the Attack segment to
+  // unity/0dB (Attack's peak is pinned, not adjustable - standard
+  // AD-envelope semantics: Attack always reaches full level), then through
+  // the Decay segment to Decay Level (the truncated content's last sample) -
+  // applied before the declick fade below so the fade's own tiny dip always
+  // lands on top of whatever the envelope left there.
+  //
+  // Both adjustable levels are unipolar attenuation-only: 0..1, 1.0 =
+  // unity/0dB, 0.0 = genuine silence. levelToDb is linear-in-dB (kSilenceDb
+  // at normalized=0, 0dB at normalized=1) - matching every other gain knob
+  // in this codebase (gainDbScale, gateDbScale, ...), so knob travel feels
+  // proportional across the whole range. A true logarithmic (20*log10(n))
+  // mapping was tried first, treating the knob's own 0..1 as if it directly
+  // were linear amplitude - but that compresses almost the entire dB range
+  // into the last sliver of travel near normalized=0 (e.g. 90% of the knob's
+  // travel, from 100% down to 10%, only covers the top 20 of 100dB; the
+  // remaining 80dB gets crammed into the last 10%), making the knob feel
+  // like it does nothing for most of its travel then cliff-dives to silent.
+  // Linear-in-dB fixes that without giving up genuine silence at the true
+  // bottom: kSilenceDb (-100dB) is a *reachable, finite* floor for the
+  // smooth part of the curve (0 < normalized <= 1), but the explicit
+  // snap-to-exact-zero below (at the precise sample a 0% level targets)
+  // handles the literal normalized=0 case separately and exactly - that
+  // discrete case is what actually guarantees true silence, not this
+  // formula's shape, so making this part linear doesn't compromise it.
+  //
+  // Each segment warps its own interpolation fraction through a power curve
+  // applied in *dB*, not linear amplitude: dB(fraction) = fromDb + (toDb -
+  // fromDb) * fraction^k, where k = kCurveMax^(2*(curveNormalized - 0.5)).
+  // This has to be the dB domain, not amplitude: true exponential decay
+  // (steep initial drop, decelerating into a long quiet tail - how real
+  // acoustic/reverb decay behaves) *is* linear-in-dB (constant ratio per
+  // sample); warping linear amplitude instead can't produce that shape at
+  // any k, and doesn't match the waveform overlay's own dB-mapped Y-axis
+  // either.
+  //
+  // Normalized 0.5 -> k=1 -> dB(fraction) is linear in fraction: constant-
+  // ratio decay, i.e. natural/"exponential" decay already, as the default.
+  // Toward 0.0, k shrinks below 1: fraction^k rises fast then levels off, so
+  // dB reaches the target almost immediately and holds there - an even
+  // steeper, more front-loaded shape. Toward 1.0, k grows past 1: fraction^k
+  // stays near 0 for most of the range then rushes to 1 at the very end, so
+  // dB holds near the segment's start level and only drops right at the
+  // finish - a back-loaded shape, the inverse. pow(0,k)=0 and pow(1,k)=1 for
+  // any k>0, so Curve only ever reshapes the *middle* of its segment - the
+  // level knobs land exactly where they say regardless of Curve. kCurveMax
+  // is a tunable constant, not a physical law; 6.0 gives real headroom at
+  // the front-loaded extreme without the knob becoming unusably twitchy near
+  // center.
+  constexpr float kCurveMax = 6.0f;
+  constexpr float kSilenceDb = -100.0f;
+  const auto levelToDb = [](float normalized) {
+    return normalized <= 0.0f ? kSilenceDb : kSilenceDb * (1.0f - normalized);
+  };
+  const float clampedInitLevel = juce::jlimit(0.0f, 1.0f, initLevelNormalized);
+  constexpr float attackDb = 0.0f;  // Attack's peak is pinned at unity/0dB
+  const float clampedDecayLevel = juce::jlimit(0.0f, 1.0f, decayLevelNormalized);
+  const float clampedAttackCurve = juce::jlimit(0.0f, 1.0f, attackCurveNormalized);
+  const float clampedDecayCurve = juce::jlimit(0.0f, 1.0f, decayCurveNormalized);
+  const bool envelopeIsFlat = clampedInitLevel == 1.0f && clampedDecayLevel == 1.0f;
+  if (targetSamples > 1 && !envelopeIsFlat) {
+    const float initDb = levelToDb(clampedInitLevel);
+    const float decayDb = levelToDb(clampedDecayLevel);
+    const float kAttack = std::pow(kCurveMax, 2.0f * (clampedAttackCurve - 0.5f));
+    const float kDecay = std::pow(kCurveMax, 2.0f * (clampedDecayCurve - 0.5f));
+    const int decaySpan = targetSamples - 1 - attackBoundary;
+    for (int i = 0; i < targetSamples; ++i) {
+      float gain;
+      if (i < attackBoundary) {
+        const float fraction = attackBoundary > 1
+                                    ? static_cast<float>(i) / static_cast<float>(attackBoundary - 1)
+                                    : 1.0f;
+        const float db = initDb + (attackDb - initDb) * std::pow(fraction, kAttack);
+        gain = juce::Decibels::decibelsToGain(db);
+      } else {
+        const float fraction =
+            decaySpan > 0 ? static_cast<float>(i - attackBoundary) / static_cast<float>(decaySpan)
+                          : 1.0f;
+        const float db = attackDb + (decayDb - attackDb) * std::pow(fraction, kDecay);
+        gain = juce::Decibels::decibelsToGain(db);
+      }
+      // True 0% must be genuine silence at the exact sample a level knob
+      // targets, not just very quiet - levelToDb's kSilenceDb floor above is
+      // only a numerical-safety approximation of that.
+      if (i == 0 && clampedInitLevel <= 0.0f)
+        gain = 0.0f;
+      else if (i == targetSamples - 1 && clampedDecayLevel <= 0.0f)
+        gain = 0.0f;
+      for (int ch = 0; ch < irNumChannels; ++ch)
+        trimmed.getWritePointer(ch)[i] *= gain;
+    }
+  }
+
+  // Short fade-out over the cut point so truncating mid-waveform doesn't
+  // ring: ~10ms, capped at a third of the trimmed length so a very short
+  // trim isn't all fade. Unconditional - the click-free guarantee shouldn't
+  // depend on where Decay Level happens to land.
+  const int fadeSamples =
+      std::min(targetSamples / 3, static_cast<int>(std::llround(rawSampleRate * 0.010)));
+  if (fadeSamples > 0) {
+    for (int i = 0; i < fadeSamples; ++i) {
+      const int sampleIndex = targetSamples - fadeSamples + i;
+      const float gain = 1.0f - static_cast<float>(i + 1) / static_cast<float>(fadeSamples);
+      for (int ch = 0; ch < irNumChannels; ++ch)
+        trimmed.getWritePointer(ch)[sampleIndex] *= gain;
+    }
+  }
+
+  // Same engine shape the block was originally classified/built as (frozen,
+  // like the short/long classification itself - a Length edit never changes
+  // either), not re-decided from the (now shorter) trimmed length.
+  auto makeConvolver = [engineLongIr] {
+    return engineLongIr ? std::make_unique<juce::dsp::Convolution>(
+                              juce::dsp::Convolution::NonUniform{kIrNonUniformHeadSamples})
+                        : std::make_unique<juce::dsp::Convolution>();
+  };
+  juce::dsp::ProcessSpec spec{kChainBaseSampleRate, static_cast<juce::uint32>(chainBaseBlockSize()),
+                              2};
+
+  // fixNumChannels (juce_Convolution.cpp) reduces to 1/2 channels internally
+  // per the Stereo flag, so the same 2-channel trimmed buffer works for both
+  // calls - just a fresh copy each time since loadImpulseResponse consumes
+  // its buffer by move.
+  auto convolverMono = makeConvolver();
+  convolverMono->loadImpulseResponse(juce::AudioBuffer<float>(trimmed), rawSampleRate,
+                                     juce::dsp::Convolution::Stereo::no,
+                                     juce::dsp::Convolution::Trim::no,
+                                     juce::dsp::Convolution::Normalise::no);
+  convolverMono->prepare(spec);
+  elapseConvolverInstallFade(*convolverMono, spec);
+  out.convolverMono = std::move(convolverMono);
+
+  if (irNumChannels > 1) {
+    auto convolverStereo = makeConvolver();
+    convolverStereo->loadImpulseResponse(std::move(trimmed), rawSampleRate,
+                                         juce::dsp::Convolution::Stereo::yes,
+                                         juce::dsp::Convolution::Trim::no,
+                                         juce::dsp::Convolution::Normalise::no);
+    convolverStereo->prepare(spec);
+    elapseConvolverInstallFade(*convolverStereo, spec);
+    out.convolverStereo = std::move(convolverStereo);
+  }
+
+  const int engineSize = out.convolverMono->getCurrentIRSize();
+  out.irLengthBaseSamples =
+      engineSize > 0 ? engineSize
+                     : static_cast<int>(std::llround(static_cast<double>(targetSamples) *
+                                                     kChainBaseSampleRate / rawSampleRate));
+  out.success = true;
+  return out;
 }
 
 juce::var TONE3000Processor::loadLocalTone(const juce::String& title, const juce::var& files,
@@ -924,18 +1198,9 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
       // block's own fade-in ends. So after prepare(), run silence through
       // the convolver until that window has provably elapsed: the install
       // and its crossfade happen here on the loader thread, and the engine
-      // goes live deterministically full-wet with silent state.
-      auto elapseConvolverInstallFade = [&spec](juce::dsp::Convolution& convolver) {
-        const int chunk = static_cast<int>(spec.maximumBlockSize);
-        juce::AudioBuffer<float> silence(static_cast<int>(spec.numChannels), chunk);
-        silence.clear();
-        // 3× JUCE's 0.05 s install fade: margin over exactness, it's cheap.
-        const int warmupSamples = static_cast<int>(kChainBaseSampleRate * 0.15);
-        for (int done = 0; done < warmupSamples; done += chunk) {
-          juce::dsp::AudioBlock<float> blockRef(silence);
-          convolver.process(juce::dsp::ProcessContextReplacing<float>(blockRef));
-        }
-      };
+      // goes live deterministically full-wet with silent state. (Shared with
+      // rebuildIrShapeInBackground's in-place rebuild - same requirement,
+      // same fix.)
 
       // Mono fallback convolver: IR channel 0 applied to every audio channel.
       auto convolverMono = makeConvolver();
@@ -943,7 +1208,7 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
                                          juce::dsp::Convolution::Trim::yes, maxIrFileSamples,
                                          juce::dsp::Convolution::Normalise::no);
       convolverMono->prepare(spec);
-      elapseConvolverInstallFade(*convolverMono);
+      elapseConvolverInstallFade(*convolverMono, spec);
       out.convolverMono = std::move(convolverMono);
 
       // True-stereo convolver: only meaningful when the file actually has 2 channels.
@@ -953,7 +1218,7 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
                                              juce::dsp::Convolution::Trim::yes, maxIrFileSamples,
                                              juce::dsp::Convolution::Normalise::no);
         convolverStereo->prepare(spec);
-        elapseConvolverInstallFade(*convolverStereo);
+        elapseConvolverInstallFade(*convolverStereo, spec);
         out.convolverStereo = std::move(convolverStereo);
       }
 
@@ -967,7 +1232,32 @@ TONE3000Processor::PreparedBlockModel TONE3000Processor::prepareBlockModelOffThr
       out.irNumChannels = irNumChannels;
       out.irLengthBaseSamples = irLengthBaseSamples;
       out.irIsLong = irLengthBaseSamples > kShortIrMaxBaseSamples;
-      out.irNormalizationGainLinear = computeIrNormalizationGain(tempFile, maxIrFileSamples);
+
+      // Read the file once, into the buffer kept as the source of truth for
+      // future editing: normalization gain and the display waveform both
+      // derive from it, rather than each reopening the file (computeIr
+      // NormalizationGain used to do exactly that on its own).
+      {
+        juce::AudioFormatManager irFormatManager;
+        irFormatManager.registerBasicFormats();
+        std::unique_ptr<juce::AudioFormatReader> irReader(
+            irFormatManager.createReaderFor(tempFile));
+        if (irReader && irReader->lengthInSamples > 0 && irReader->numChannels > 0) {
+          const juce::int64 samplesToRead = std::min<juce::int64>(
+              irReader->lengthInSamples, static_cast<juce::int64>(maxIrFileSamples));
+          out.irRawSamples.setSize(static_cast<int>(irReader->numChannels),
+                                   static_cast<int>(samplesToRead));
+          irReader->read(&out.irRawSamples, 0, static_cast<int>(samplesToRead), 0, true, true);
+          out.irRawSampleRate =
+              irReader->sampleRate > 0.0 ? irReader->sampleRate : kChainBaseSampleRate;
+        }
+      }
+      out.irNormalizationGainLinear =
+          computeIrNormalizationGain(out.irRawSamples, out.irRawSampleRate);
+      out.irContentLengthSamples =
+          computeIrContentLengthSamples(out.irRawSamples, out.irRawSampleRate);
+      out.irWaveformPeaks = computeIrWaveformPeaks(out.irRawSamples, kIrWaveformColumns,
+                                                    out.irContentLengthSamples);
 
       juce::Logger::writeToLog(
           "[ModelLoader] IR prepared: " + juce::String(irNumChannels) + " ch, " +
@@ -1227,6 +1517,16 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     block.irNumChannels = 1;
     block.irLengthBaseSamples = 0;
     block.irIsLong = false;
+    block.irRawSamples.setSize(0, 0);
+    block.irRawSampleRate = 0.0;
+    block.irContentLengthSamples = 0;
+    block.irWaveformPeaks.clear();
+    block.initLevelNormalized = 1.0f;
+    block.attackLengthNormalized = 0.0f;
+    block.attackCurveNormalized = 0.5f;
+    block.decayLengthNormalized = 1.0f;
+    block.decayLevelNormalized = 1.0f;
+    block.decayCurveNormalized = 0.5f;
 
     // Re-assert the block's A2 size in case it changed while this engine
     // was downloading/preparing (a no-op retier when it didn't).
@@ -1245,6 +1545,10 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     block.irNumChannels = prepared.irNumChannels;
     block.irLengthBaseSamples = prepared.irLengthBaseSamples;
     block.irIsLong = prepared.irIsLong;
+    block.irRawSamples = std::move(prepared.irRawSamples);
+    block.irRawSampleRate = prepared.irRawSampleRate;
+    block.irContentLengthSamples = prepared.irContentLengthSamples;
+    block.irWaveformPeaks = std::move(prepared.irWaveformPeaks);
 
     // The base-rate island around the convolvers: blocks added mid-session
     // were never seen by prepareChain, so (re)prepare it here with the same
@@ -1262,9 +1566,28 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     // IRs are reverbs/effects meant to be blended (half wet), short cab IRs
     // replace the signal (fully wet). Length is only known here, after the
     // download, so loadTone arms this one-shot flag instead of guessing
-    // from tone metadata. Swaps/restores keep the user's mix.
-    if (block.applyDefaultMixOnLoad)
+    // from tone metadata. Swaps/restores keep the user's mix - and, the same
+    // way, keep the user's envelope shaping rather than starting the new
+    // content untouched.
+    if (block.applyDefaultMixOnLoad) {
       block.mixNormalized = block.irIsLong ? 0.5f : 1.0f;
+      block.initLevelNormalized = 1.0f;
+      block.attackLengthNormalized = 0.0f;
+      block.attackCurveNormalized = 0.5f;
+      block.decayLengthNormalized = 1.0f;
+      block.decayLevelNormalized = 1.0f;
+      block.decayCurveNormalized = 0.5f;
+    } else if (block.attackLengthNormalized != 0.0f || block.decayLengthNormalized != 1.0f ||
+               block.initLevelNormalized != 1.0f || block.decayLevelNormalized != 1.0f) {
+      // A prior envelope shape survives the swap/restore as persisted
+      // values, but the engine just built above is always full-length and
+      // flat (prepareBlockModelOffThread doesn't know about it) - queue a
+      // rebuild to reapply it, exactly like a live envelope edit would.
+      const int generation = ++block.irShapingGeneration;
+      loadingThreadPool.addJob(std::function<void()>([this, blockId = block.id, generation]() {
+        rebuildIrShapeInBackground(blockId, generation);
+      }));
+    }
 
     block.irNormalizationGainLinear = prepared.irNormalizationGainLinear;
     block.irNormalizationSmoother.reset(chainSampleRate(), 0.05f);

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -509,26 +509,38 @@ TONE3000Processor::PreparedIrShapeRebuild TONE3000Processor::prepareIrShapeRebui
   // finish - a back-loaded shape, the inverse. pow(0,k)=0 and pow(1,k)=1 for
   // any k>0, so Curve only ever reshapes the *middle* of its segment - the
   // level knobs land exactly where they say regardless of Curve. kCurveMax
-  // is a tunable constant, not a physical law; 6.0 gives real headroom at
-  // the extremes (front-/back-loaded enough to sound gated), reachable only
-  // at the very ends of the knob's travel.
+  // is a tunable constant, not a physical law - 4.0 is deliberately more
+  // conservative than a first pass at 6.0: real reverb/room IRs already
+  // carry their own natural decay, and the envelope's dB drop *adds* to
+  // that (dB is logarithmic, so multiplying amplitudes is adding dB) rather
+  // than replacing it - even the intentional, full-knob-throw extreme (not
+  // just an accidental small drag - see shapeCurveNormalized below for
+  // that) stacked an already-steep artificial cutoff on top of whatever the
+  // IR's own tail was already doing, and by ear that read as a hard gate
+  // rather than a usable creative curve. At kCurveMax=4.0, full throw's
+  // end-of-segment slope is still 4x steeper than linear (a real, audible
+  // difference) but roughly an order of magnitude less compressed at the
+  // 30%-into-the-segment mark than 6.0 was (0.81% of the total dB change by
+  // then, vs. 0.07%).
   //
   // curveNormalized isn't fed to the exponent linearly, though - it goes
   // through shapeCurveNormalized() first. A straight kCurveMax^(2*(c-0.5))
   // swings k a lot for even a small move off center (dk/dc at c=0.5 is
-  // 2*ln(kCurveMax) =~ 3.6), and because fraction^k is applied against dB's
-  // own huge dynamic range, a "small" k deviation from 1 (say 2) already
-  // looks almost like a step function (91% of the segment's whole dB change
-  // lands in its last 30%) - a small, easy-to-do-by-accident drag produced
-  // an audibly extreme "choke" the on-screen curve (sampled coarsely for
-  // display) didn't visually convey. Cubing (curveNormalized - 0.5) before
-  // exponentiating spreads that sensitivity unevenly across the knob's
-  // travel: the same extremes (k=1/kCurveMax at c=0, k=kCurveMax at c=1)
-  // are still reachable at full throw, but landing any given k in between
-  // now takes roughly double the drag distance it used to near center - see
-  // decayEnvelope.ts's own copy of this shaping, which must stay in sync by
-  // hand (no shared code across the C++/TS boundary).
-  constexpr float kCurveMax = 6.0f;
+  // 2*ln(kCurveMax)), and because fraction^k is applied against dB's own
+  // huge dynamic range, a "small" k deviation from 1 (say 2) already looks
+  // almost like a step function - a small, easy-to-do-by-accident drag
+  // produced an audibly extreme "choke" the on-screen curve (sampled
+  // coarsely for display) didn't visually convey. Cubing
+  // (curveNormalized - 0.5) before exponentiating spreads that sensitivity
+  // unevenly across the knob's travel: the same extremes (k=1/kCurveMax at
+  // c=0, k=kCurveMax at c=1) are still reachable at full throw, but landing
+  // any given k in between now takes meaningfully more drag near center -
+  // see decayEnvelope.ts's own copy of this shaping, which must stay in
+  // sync by hand (no shared code across the C++/TS boundary). This and the
+  // kCurveMax value above are two independent levers - one controls how
+  // much drag reaches a given curve, the other controls how extreme the
+  // curve can get at all - and both needed tuning down after listening.
+  constexpr float kCurveMax = 4.0f;
   constexpr float kSilenceDb = -100.0f;
   const auto levelToDb = [](float normalized) {
     return normalized <= 0.0f ? kSilenceDb : kSilenceDb * (1.0f - normalized);

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -510,12 +510,32 @@ TONE3000Processor::PreparedIrShapeRebuild TONE3000Processor::prepareIrShapeRebui
   // any k>0, so Curve only ever reshapes the *middle* of its segment - the
   // level knobs land exactly where they say regardless of Curve. kCurveMax
   // is a tunable constant, not a physical law; 6.0 gives real headroom at
-  // the front-loaded extreme without the knob becoming unusably twitchy near
-  // center.
+  // the extremes (front-/back-loaded enough to sound gated), reachable only
+  // at the very ends of the knob's travel.
+  //
+  // curveNormalized isn't fed to the exponent linearly, though - it goes
+  // through shapeCurveNormalized() first. A straight kCurveMax^(2*(c-0.5))
+  // swings k a lot for even a small move off center (dk/dc at c=0.5 is
+  // 2*ln(kCurveMax) =~ 3.6), and because fraction^k is applied against dB's
+  // own huge dynamic range, a "small" k deviation from 1 (say 2) already
+  // looks almost like a step function (91% of the segment's whole dB change
+  // lands in its last 30%) - a small, easy-to-do-by-accident drag produced
+  // an audibly extreme "choke" the on-screen curve (sampled coarsely for
+  // display) didn't visually convey. Cubing (curveNormalized - 0.5) before
+  // exponentiating spreads that sensitivity unevenly across the knob's
+  // travel: the same extremes (k=1/kCurveMax at c=0, k=kCurveMax at c=1)
+  // are still reachable at full throw, but landing any given k in between
+  // now takes roughly double the drag distance it used to near center - see
+  // decayEnvelope.ts's own copy of this shaping, which must stay in sync by
+  // hand (no shared code across the C++/TS boundary).
   constexpr float kCurveMax = 6.0f;
   constexpr float kSilenceDb = -100.0f;
   const auto levelToDb = [](float normalized) {
     return normalized <= 0.0f ? kSilenceDb : kSilenceDb * (1.0f - normalized);
+  };
+  const auto shapeCurveNormalized = [](float c) {
+    const float d = c - 0.5f;
+    return std::copysign(std::pow(std::abs(2.0f * d), 3.0f), d) * 0.5f;
   };
   const float clampedInitLevel = juce::jlimit(0.0f, 1.0f, initLevelNormalized);
   constexpr float attackDb = 0.0f;  // Attack's peak is pinned at unity/0dB
@@ -526,8 +546,8 @@ TONE3000Processor::PreparedIrShapeRebuild TONE3000Processor::prepareIrShapeRebui
   if (targetSamples > 1 && !envelopeIsFlat) {
     const float initDb = levelToDb(clampedInitLevel);
     const float decayDb = levelToDb(clampedDecayLevel);
-    const float kAttack = std::pow(kCurveMax, 2.0f * (clampedAttackCurve - 0.5f));
-    const float kDecay = std::pow(kCurveMax, 2.0f * (clampedDecayCurve - 0.5f));
+    const float kAttack = std::pow(kCurveMax, 2.0f * shapeCurveNormalized(clampedAttackCurve));
+    const float kDecay = std::pow(kCurveMax, 2.0f * shapeCurveNormalized(clampedDecayCurve));
     const int decaySpan = targetSamples - 1 - attackBoundary;
     for (int i = 0; i < targetSamples; ++i) {
       float gain;

--- a/plugin/src/ProcessorModelLoader.cpp
+++ b/plugin/src/ProcessorModelLoader.cpp
@@ -1252,6 +1252,11 @@ void TONE3000Processor::applyPreparedModelToChainBlock(ChainBlock& block, ChainB
     // small work buffers), and the swap-fade already has the wet path silent.
     block.irBaseRateIsland.prepare(chainOversampleFactor.load(),
                                    juce::jmax(1, chainBaseBlockSize()));
+    // Same "never seen by prepareChain" reasoning applies to the predelay
+    // ring buffer: it must be sized here too, or a block loaded mid-session
+    // processes with an unprepared (zero-capacity) buffer.
+    block.predelay.prepare(kChainBaseSampleRate,
+                           block.predelayNormalized * BlockPredelay::kMaxDelayMs);
 
     // Fresh blocks (Select-flow loads) default their mix by IR length: long
     // IRs are reverbs/effects meant to be blended (half wet), short cab IRs

--- a/plugin/src/ProcessorState.cpp
+++ b/plugin/src/ProcessorState.cpp
@@ -131,6 +131,7 @@ juce::ValueTree TONE3000Processor::serializeBlockSettings(const ChainBlock& bloc
   blockState.setProperty("inputGain", block.inputGainNormalized, nullptr);
   blockState.setProperty("outputGain", block.outputGainNormalized, nullptr);
   blockState.setProperty("mix", block.mixNormalized, nullptr);
+  blockState.setProperty("predelay", block.predelayNormalized, nullptr);
 
   if (block.type != ChainBlockType::INSERT) {
     blockState.setProperty("toneId", block.toneId, nullptr);
@@ -148,6 +149,8 @@ void TONE3000Processor::applyBlockSettings(ChainBlock& block, const juce::ValueT
   block.inputGainNormalized = static_cast<float>(blockState.getProperty("inputGain", 0.5f));
   block.outputGainNormalized = static_cast<float>(blockState.getProperty("outputGain", 0.5f));
   block.mixNormalized = static_cast<float>(blockState.getProperty("mix", 1.0f));
+  block.predelayNormalized =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(blockState.getProperty("predelay", 0.0f)));
 
   // States from before per-block sizes restore as lite (0.0). An engine the
   // restore keeps loaded (see reconcileChainFromTree) retiers in place: the

--- a/plugin/src/ProcessorState.cpp
+++ b/plugin/src/ProcessorState.cpp
@@ -132,6 +132,12 @@ juce::ValueTree TONE3000Processor::serializeBlockSettings(const ChainBlock& bloc
   blockState.setProperty("outputGain", block.outputGainNormalized, nullptr);
   blockState.setProperty("mix", block.mixNormalized, nullptr);
   blockState.setProperty("predelay", block.predelayNormalized, nullptr);
+  blockState.setProperty("initLevel", block.initLevelNormalized, nullptr);
+  blockState.setProperty("attackLength", block.attackLengthNormalized, nullptr);
+  blockState.setProperty("attackCurve", block.attackCurveNormalized, nullptr);
+  blockState.setProperty("decayLength", block.decayLengthNormalized, nullptr);
+  blockState.setProperty("decayLevel", block.decayLevelNormalized, nullptr);
+  blockState.setProperty("decayCurve", block.decayCurveNormalized, nullptr);
 
   if (block.type != ChainBlockType::INSERT) {
     blockState.setProperty("toneId", block.toneId, nullptr);
@@ -151,6 +157,18 @@ void TONE3000Processor::applyBlockSettings(ChainBlock& block, const juce::ValueT
   block.mixNormalized = static_cast<float>(blockState.getProperty("mix", 1.0f));
   block.predelayNormalized =
       juce::jlimit(0.0f, 1.0f, static_cast<float>(blockState.getProperty("predelay", 0.0f)));
+  block.initLevelNormalized =
+      juce::jlimit(0.0f, 1.0f, static_cast<float>(blockState.getProperty("initLevel", 1.0f)));
+  block.attackLengthNormalized = juce::jlimit(
+      0.0f, 1.0f, static_cast<float>(blockState.getProperty("attackLength", 0.0f)));
+  block.attackCurveNormalized = juce::jlimit(
+      0.0f, 1.0f, static_cast<float>(blockState.getProperty("attackCurve", 0.5f)));
+  block.decayLengthNormalized = juce::jlimit(
+      0.0f, 1.0f, static_cast<float>(blockState.getProperty("decayLength", 1.0f)));
+  block.decayLevelNormalized = juce::jlimit(
+      0.0f, 1.0f, static_cast<float>(blockState.getProperty("decayLevel", 1.0f)));
+  block.decayCurveNormalized = juce::jlimit(
+      0.0f, 1.0f, static_cast<float>(blockState.getProperty("decayCurve", 0.5f)));
 
   // States from before per-block sizes restore as lite (0.0). An engine the
   // restore keeps loaded (see reconcileChainFromTree) retiers in place: the

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,8 @@ target_sources(DspTests PRIVATE
     src/dsp_tests.cpp
     src/duplicate_tests.cpp
     src/eq_post_routing_tests.cpp
+    src/ir_content_length_tests.cpp
+    src/ir_decay_tests.cpp
     src/ir_temp_file_tests.cpp
     src/local_load_tests.cpp
     src/midi_map_tests.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(DspTests PRIVATE
     src/midi_map_tests.cpp
     src/multicore_tests.cpp
     src/outgain_tests.cpp
+    src/predelay_tests.cpp
     src/preset_tests.cpp
     src/processor_tests.cpp
     src/spread_tests.cpp
@@ -40,6 +41,7 @@ target_sources(DspTests PRIVATE
     # compiles the processor exactly like the headless plugin build.
     ../plugin/src/AutoOffset.cpp
     ../plugin/src/BlockEq.cpp
+    ../plugin/src/BlockPredelay.cpp
     ../plugin/src/BlockSpectrum.cpp
     ../plugin/src/MidiMapper.cpp
     ../plugin/src/NamEngine.cpp

--- a/test/src/ir_content_length_tests.cpp
+++ b/test/src/ir_content_length_tests.cpp
@@ -1,0 +1,61 @@
+// Pins computeIrContentLengthSamples's effect (ProcessorModelLoader.cpp): the
+// -60dB-relative-to-peak, backward-scanned pooled-RMS detector that is the
+// single source of truth for both the waveform display's auto-fit trim
+// (computeIrWaveformPeaks) and the length label shipped to the UI as
+// irContentLengthMs. It's a private static helper (like its siblings
+// computeIrNormalizationGain/computeIrWaveformPeaks, neither unit-tested in
+// isolation either), so this drives it through the real load pipeline
+// instead of calling it directly.
+#include "chain_test_helpers.h"
+
+namespace {
+
+double contentLengthMsFor(ChainTestProcessor& proc, const juce::String& blockId) {
+  const juce::var state = proc.getChainState(-1);
+  for (const auto& item : *state["chain"].getArray())
+    if (item["blockId"].toString() == blockId)
+      return static_cast<double>(item["irContentLengthMs"]);
+  ADD_FAILURE() << "block " << blockId << " not found in chain state";
+  return -1.0;
+}
+
+}  // namespace
+
+// cab-ir-test.wav (~500ms raw file): whatever the detector reports must be
+// positive and can never exceed the file's own raw duration - the detector
+// only ever trims, never extends.
+TEST(IrContentLengthTest, CabIrLengthIsPositiveAndWithinRawDuration) {
+  ChainTestProcessor proc;
+  proc.setPlayConfigDetails(2, 2, kFs, 512);
+  proc.prepareToPlay(kFs, 512);
+
+  seedStereoChains(proc, {"blk-a"}, {});
+  ASSERT_TRUE(waitForChainLoaded(proc));
+
+  const double lengthMs = contentLengthMsFor(proc, "blk-a");
+  EXPECT_GT(lengthMs, 0.0);
+  // afinfo reports cab-ir-test.wav at 500.021ms; a couple ms of tolerance
+  // for rounding across the file-rate <-> ms conversion.
+  EXPECT_LT(lengthMs, 505.0) << "content length exceeds the cab IR's own raw duration";
+}
+
+// reverb-ir-mono-test.wav (~2.665s raw file): same bound, on a much longer,
+// non-cab-classified file - the detector isn't cab-specific.
+TEST(IrContentLengthTest, ReverbIrLengthIsPositiveAndWithinRawDuration) {
+  ChainTestProcessor proc;
+  proc.setPlayConfigDetails(2, 2, kFs, 512);
+  proc.prepareToPlay(kFs, 512);
+
+  juce::ValueTree state("ChainSnapshot");
+  state.setProperty("stereoEnabled", false, nullptr);
+  juce::ValueTree lane("ChainBlocks");
+  lane.appendChild(makeIrBlockTree("blk-a", 1, 100, "reverb-ir-mono-test.wav"), nullptr);
+  state.appendChild(lane, nullptr);
+  state.appendChild(juce::ValueTree("RightChainBlocks"), nullptr);
+  proc.restoreFromTree(state);
+  ASSERT_TRUE(waitForChainLoaded(proc));
+
+  const double lengthMs = contentLengthMsFor(proc, "blk-a");
+  EXPECT_GT(lengthMs, 0.0);
+  EXPECT_LT(lengthMs, 2670.0) << "content length exceeds the reverb IR's own raw duration";
+}

--- a/test/src/ir_decay_tests.cpp
+++ b/test/src/ir_decay_tests.cpp
@@ -1,0 +1,399 @@
+// Pins the IR envelope: setBlockIrDecay shapes a 2-segment Attack/Decay gain
+// envelope over the truncated IR content (Init Level at sample 0, ramping
+// through Attack to unity/0dB - Attack's peak is pinned, not adjustable -
+// then through Decay to Decay Level - see
+// TONE3000Processor::prepareIrShapeRebuild), feeding the same off-thread
+// rebuild path Length used to (rebuildIrShapeInBackground), never touches the
+// dry path, and the shape survives a state round-trip. Decay Length is the
+// TOTAL truncated length (the real "End" position, a fraction of the
+// block's full detected content); Attack Length is a fraction *of that
+// total*, marking where the peak sits within it - this file also covers
+// what ir_length_tests.cpp used to (Length no longer exists as its own
+// knob, folded into Decay Length).
+#include "chain_test_helpers.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace {
+constexpr int kBlock = 512;
+
+void seedMonoIrChain(ChainTestProcessor& proc, const juce::String& blockId,
+                     const char* fileName = "reverb-ir-mono-test.wav") {
+  juce::ValueTree state("ChainSnapshot");
+  state.setProperty("stereoEnabled", false, nullptr);
+  juce::ValueTree lane("ChainBlocks");
+  lane.appendChild(makeIrBlockTree(blockId, 1, 100, fileName), nullptr);
+  state.appendChild(lane, nullptr);
+  state.appendChild(juce::ValueTree("RightChainBlocks"), nullptr);
+  proc.restoreFromTree(state);
+}
+
+// See ir_length_tests.cpp's (removed) own copy of this helper for the full
+// story: a naive sleep-based wait lets requestSwapFadeAndWait's
+// !isAudioActive() early return skip the entire mute/unmute mechanism,
+// silently testing the wrong code path. Keep the heartbeat alive with small
+// silent pumps throughout, priming immediately before the triggering call so
+// there's no cold gap before the background job can reach its own
+// fade-request.
+void pumpAudio(ChainTestProcessor& proc, int totalMs, bool alreadyWarm = false) {
+  const std::vector<float> silence(static_cast<size_t>(kBlock), 0.0f);
+  constexpr int kPumpIntervalMs = 50;
+  if (!alreadyWarm)
+    processStereo(proc, silence);
+  for (int elapsed = 0; elapsed < totalMs; elapsed += kPumpIntervalMs) {
+    juce::Thread::sleep(kPumpIntervalMs);
+    processStereo(proc, silence);
+  }
+}
+
+// Mirrors ChainBlock.h's own no-op defaults: no attack ramp, decay spans the
+// full (remaining) content, every level at unity. Attack's peak is pinned at
+// unity/0dB (not a param), matching standard AD-envelope semantics.
+struct EnvelopeParams {
+  double initLevel = 1.0;
+  double attackLength = 0.0;
+  double attackCurve = 0.5;
+  double decayLength = 1.0;
+  double decayLevel = 1.0;
+  double decayCurve = 0.5;
+};
+
+void setEnvelopeAndWaitForRebuild(ChainTestProcessor& proc, const char* blockId,
+                                  const EnvelopeParams& p) {
+  const std::vector<float> silence(static_cast<size_t>(kBlock), 0.0f);
+  processStereo(proc, silence);  // prime
+  ASSERT_TRUE(proc.setBlockIrDecay(blockId, p.initLevel, p.attackLength, p.attackCurve,
+                                   p.decayLength, p.decayLevel, p.decayCurve));
+  pumpAudio(proc, 1200, /*alreadyWarm=*/true);
+}
+
+// Placed well into the buffer (not sample 0, mirroring
+// PredelayTest.DelaysOnlyTheWetPath): a spike at the very start can get
+// suppressed by the input noise gate before it ever reaches the convolver.
+constexpr int kImpulseBlock = 15;
+constexpr size_t kImpulseOnset = static_cast<size_t>(kImpulseBlock) * kBlock;
+
+std::vector<float> makeDelayedImpulse(int totalBlocks) {
+  std::vector<float> impulse(static_cast<size_t>(totalBlocks * kBlock), 0.0f);
+  impulse[kImpulseOnset] = 1.0f;
+  return impulse;
+}
+
+// Continuous noise integrates across the *whole* kernel on every output
+// sample (each sample is a convolution sum over all taps), so a change
+// confined to the tail barely moves overall RMS - not useful for isolating
+// the envelope's effect. A single impulse instead traces the (now-shaped)
+// kernel directly: output[onset + i] is just kernel[i] (scaled by any live
+// gains).
+size_t lastAboveFloor(const std::vector<float>& v, float floor) {
+  for (size_t i = v.size(); i-- > kImpulseOnset;)
+    if (std::abs(v[i]) > floor) return i;
+  return kImpulseOnset;
+}
+
+double rmsFrom(const std::vector<float>& v, size_t from) {
+  double sumSq = 0.0;
+  size_t n = 0;
+  for (size_t i = from; i < v.size(); ++i) {
+    sumSq += static_cast<double>(v[i]) * v[i];
+    ++n;
+  }
+  return n > 0 ? std::sqrt(sumSq / n) : 0.0;
+}
+}  // namespace
+
+// A shorter Decay Length (with Attack at its default zero) should measurably
+// shrink the convolved tail relative to the default (untruncated) envelope -
+// the direct signature that Attack+Decay Length together replace what the
+// old standalone Length knob did.
+TEST(IrDecayTest, TruncatesViaAttackAndDecayLength) {
+  constexpr int kTotalBlocks = 90;  // kImpulseBlock (43ms) + past the reverb IR's own tail
+  const auto impulse = makeDelayedImpulse(kTotalBlocks);
+  const float floor = 1e-4f;
+
+  auto runWithDecayLength = [&](double decayLength) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+    seedMonoIrChain(proc, "blk-a");
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));  // fully wet
+    EnvelopeParams p;
+    p.decayLength = decayLength;
+    setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+    letAudioGoIdle();
+    return processStereo(proc, impulse);
+  };
+
+  const auto [fullL, fullR] = runWithDecayLength(1.0);
+  const auto [halfL, halfR] = runWithDecayLength(0.5);
+  juce::ignoreUnused(fullR, halfR);
+
+  const size_t fullTail = lastAboveFloor(fullL, floor);
+  const size_t halfTail = lastAboveFloor(halfL, floor);
+  ASSERT_GT(fullTail, kImpulseOnset) << "full-length run produced no measurable tail at all";
+  std::printf("[IrDecayTest] tail extent (samples past onset) full=%zu, decayLength=0.5 -> %zu\n",
+              fullTail - kImpulseOnset, halfTail - kImpulseOnset);
+  // Not a tight proportionality check: the measured tail is the convolution
+  // output crossing a floor, not the raw kernel length, so a 50% kernel
+  // truncation doesn't map to an exactly-50% shorter measured tail. This
+  // just needs to show truncation is clearly happening.
+  EXPECT_LT(halfTail - kImpulseOnset, (fullTail - kImpulseOnset) * 0.85)
+      << "halving Decay Length doesn't appear to be truncating the convolved tail";
+}
+
+// Mirrors PredelayTest.DoesNotAffectDryPath / the old IrLengthTest/IrDecayTest
+// dry-path checks: at mix=0, only the envelope differs between the two runs,
+// so any leak into dry shows up as a real divergence, not floating-point
+// noise.
+TEST(IrDecayTest, DoesNotAffectDryPath) {
+  auto runWithEnvelope = [](const EnvelopeParams& p) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+    seedMonoIrChain(proc, "blk-a");
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 0.0));  // pure dry
+    setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+    letAudioGoIdle();
+
+    constexpr int kWarmupBlocks = 15;
+    processStereo(proc, makeNoise(kWarmupBlocks * kBlock, 1111, 0.25f));
+    return processStereo(proc, makeNoise(20 * kBlock, 4242, 0.25f));
+  };
+
+  EnvelopeParams neutral;
+  EnvelopeParams shaped;
+  shaped.decayLength = 0.5;
+  shaped.decayLevel = 0.0;
+
+  const auto [neutralL, neutralR] = runWithEnvelope(neutral);
+  const auto [shapedL, shapedR] = runWithEnvelope(shaped);
+
+  ASSERT_EQ(neutralL.size(), shapedL.size());
+  float maxAbsDiff = 0.0f;
+  for (size_t i = 0; i < neutralL.size(); ++i) {
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(neutralL[i] - shapedL[i]));
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(neutralR[i] - shapedR[i]));
+  }
+  const float maxAbsDiffDb = juce::Decibels::gainToDecibels(maxAbsDiff, -300.0f);
+  std::printf("[IrDecayTest] max |diff| between neutral and shaped envelope at mix=0: %.9f (%.1f dB)\n",
+              static_cast<double>(maxAbsDiff), static_cast<double>(maxAbsDiffDb));
+  EXPECT_LT(maxAbsDiff, 1e-4f) << "dry path diverges far more than floating-point rounding noise "
+                                  "explains - the envelope is likely leaking into the dry signal";
+}
+
+// A Decay Level of 0.0 (true silence, not just "quiet") should collapse the
+// late tail far more than the neutral (1.0/unity) default - the basic
+// signature that the level knobs are shaping gain over time, not just
+// applying a flat overall gain change (which Out Gain already covers), and
+// that 0% genuinely means silence rather than a modest attenuation.
+TEST(IrDecayTest, LowDecayLevelAttenuatesLateTailEnergy) {
+  constexpr int kTotalBlocks = 90;
+  const auto impulse = makeDelayedImpulse(kTotalBlocks);
+  const float floor = 1e-4f;
+
+  auto runWithDecayLevel = [&](double decayLevel) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+    seedMonoIrChain(proc, "blk-a");
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));  // fully wet
+    EnvelopeParams p;
+    p.decayLevel = decayLevel;
+    setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+    letAudioGoIdle();
+    return processStereo(proc, impulse);
+  };
+
+  const auto [neutralL, neutralR] = runWithDecayLevel(1.0);
+  const auto [zeroL, zeroR] = runWithDecayLevel(0.0);  // true silence at the end
+  juce::ignoreUnused(neutralR, zeroR);
+
+  // Late window: the last 30% of the neutral run's own measured tail extent,
+  // applied identically to both runs - exactly where Decay Level's influence
+  // dominates the envelope.
+  const size_t neutralTail = lastAboveFloor(neutralL, floor);
+  ASSERT_GT(neutralTail, kImpulseOnset) << "neutral run produced no measurable tail at all";
+  const size_t lateStart =
+      kImpulseOnset + static_cast<size_t>((neutralTail - kImpulseOnset) * 0.7);
+
+  const double rmsNeutralLate = rmsFrom(neutralL, lateStart);
+  const double rmsZeroLate = rmsFrom(zeroL, lateStart);
+  ASSERT_GT(rmsNeutralLate, 0.0) << "neutral run's late window is silent - fixture is broken";
+
+  std::printf("[IrDecayTest] late-window rms neutral=%.9f, Decay Level=0%%=%.9f\n", rmsNeutralLate,
+              rmsZeroLate);
+  EXPECT_LT(rmsZeroLate, rmsNeutralLate * 0.1)
+      << "Decay Level=0% doesn't appear to be collapsing the tail's gain anywhere near silence";
+}
+
+// Two different Decay Curve values, same (non-flat) Decay Level, must
+// produce genuinely different output - proves decayCurveNormalized actually
+// warps the Decay segment's shape, not a no-op. Uses the curve knob's two
+// extremes (0.0 front-loaded: steep initial drop; 1.0 back-loaded: holds,
+// then drops at the very end) for the widest divergence. Attack stays at its
+// default zero length, so the whole truncated content is the Decay segment.
+TEST(IrDecayTest, DecayCurveShapesTheMiddleOfTheDecaySegment) {
+  auto runWithCurve = [](double decayCurve) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+    seedMonoIrChain(proc, "blk-a");
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));
+    EnvelopeParams p;
+    p.decayLevel = 0.0;  // a real envelope to shape
+    p.decayCurve = decayCurve;
+    setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+    letAudioGoIdle();
+
+    constexpr int kWarmupBlocks = 15;
+    processStereo(proc, makeNoise(kWarmupBlocks * kBlock, 1111, 0.25f));
+    return processStereo(proc, makeNoise(20 * kBlock, 4242, 0.25f));
+  };
+
+  const auto [frontLoadedL, frontLoadedR] = runWithCurve(0.0);
+  const auto [backLoadedL, backLoadedR] = runWithCurve(1.0);
+
+  ASSERT_EQ(frontLoadedL.size(), backLoadedL.size());
+  float maxAbsDiff = 0.0f;
+  for (size_t i = 0; i < frontLoadedL.size(); ++i) {
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(frontLoadedL[i] - backLoadedL[i]));
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(frontLoadedR[i] - backLoadedR[i]));
+  }
+  std::printf(
+      "[IrDecayTest] max |diff| between Decay Curve=0.0 (front-loaded) and =1.0 (back-loaded): %.9f\n",
+      static_cast<double>(maxAbsDiff));
+  EXPECT_GT(maxAbsDiff, 1e-3f)
+      << "Decay Curve's two extremes produced effectively identical output - "
+         "decayCurveNormalized doesn't appear to change the Decay segment's shape";
+}
+
+// Same proof as the Decay Curve test above, but for the (new) independent
+// Attack segment: Decay Length sets a real (half-content) total, and Attack
+// Length=1.0 puts the peak at the very end of that total - so the whole
+// truncated content is the Attack segment (decay span = 0), isolating Attack
+// Curve's own effect. Fades in from Init Level=0 (silence) up to unity/0dB
+// (Attack's pinned peak).
+TEST(IrDecayTest, AttackCurveShapesTheMiddleOfTheAttackSegment) {
+  auto runWithCurve = [](double attackCurve) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+    seedMonoIrChain(proc, "blk-a");
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));
+    EnvelopeParams p;
+    p.initLevel = 0.0;  // a real envelope to shape (fade-in to Attack's unity peak)
+    p.attackLength = 1.0;  // peak at the very end of the total - decay span = 0
+    p.attackCurve = attackCurve;
+    p.decayLength = 0.5;  // a real (half-content) total for Attack to span
+    setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+    letAudioGoIdle();
+
+    constexpr int kWarmupBlocks = 15;
+    processStereo(proc, makeNoise(kWarmupBlocks * kBlock, 1111, 0.25f));
+    return processStereo(proc, makeNoise(20 * kBlock, 4242, 0.25f));
+  };
+
+  const auto [frontLoadedL, frontLoadedR] = runWithCurve(0.0);
+  const auto [backLoadedL, backLoadedR] = runWithCurve(1.0);
+
+  ASSERT_EQ(frontLoadedL.size(), backLoadedL.size());
+  float maxAbsDiff = 0.0f;
+  for (size_t i = 0; i < frontLoadedL.size(); ++i) {
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(frontLoadedL[i] - backLoadedL[i]));
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(frontLoadedR[i] - backLoadedR[i]));
+  }
+  std::printf(
+      "[IrDecayTest] max |diff| between Attack Curve=0.0 and =1.0: %.9f\n",
+      static_cast<double>(maxAbsDiff));
+  EXPECT_GT(maxAbsDiff, 1e-3f)
+      << "Attack Curve's two extremes produced effectively identical output - "
+         "attackCurveNormalized doesn't appear to change the Attack segment's shape";
+}
+
+// The envelope shape is persisted, but the *audible* shape only exists
+// because it's reapplied to the freshly rebuilt (always full-length, flat)
+// engine on restore - pins the generalized reapply condition in
+// applyPreparedModelToChainBlock (an OR across all six params).
+TEST(IrDecayTest, ShapeReappliesAfterStateRestore) {
+  constexpr int kTotalBlocks = 90;
+  const auto impulse = makeDelayedImpulse(kTotalBlocks);
+
+  ChainTestProcessor proc;
+  proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+  proc.prepareToPlay(kFs, kBlock);
+  seedMonoIrChain(proc, "blk-a");
+  ASSERT_TRUE(waitForChainLoaded(proc));
+  ASSERT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));
+  // A nontrivial combo across all six params, exercising Attack, Decay, both
+  // curves, and a true-zero level together through the restore path.
+  EnvelopeParams p;
+  p.initLevel = 0.7;
+  p.attackLength = 0.3;
+  p.attackCurve = 0.2;
+  p.decayLength = 0.5;
+  p.decayLevel = 0.0;
+  p.decayCurve = 0.9;
+  setEnvelopeAndWaitForRebuild(proc, "blk-a", p);
+  letAudioGoIdle();
+
+  const auto [beforeL, beforeR] = processStereo(proc, impulse);
+
+  juce::MemoryBlock savedState;
+  proc.getStateInformation(savedState);
+
+  ChainTestProcessor restored;
+  restored.setPlayConfigDetails(2, 2, kFs, kBlock);
+  restored.prepareToPlay(kFs, kBlock);
+  restored.setStateInformation(savedState.getData(), static_cast<int>(savedState.getSize()));
+
+  // waitForChainLoaded only polls getChainState, never processBlock, so the
+  // reapply job the restore's own load queues (applyPreparedModelToChainBlock)
+  // can fire its requestSwapFadeAndWait before or during this wait - pump
+  // throughout, not just once loaded.
+  bool loaded = false;
+  {
+    const std::vector<float> silence(static_cast<size_t>(kBlock), 0.0f);
+    const auto deadline = juce::Time::getMillisecondCounter() + 5000u;
+    while (juce::Time::getMillisecondCounter() < deadline) {
+      processStereo(restored, silence);
+      const juce::var state = restored.getChainState(-1);
+      bool allLoaded = true;
+      for (const auto* lane : {state["chain"].getArray(), state["chainRight"].getArray()}) {
+        if (lane == nullptr)
+          continue;
+        for (const auto& item : *lane)
+          if (item["kind"].toString() == "tone" && !static_cast<bool>(item["loaded"]))
+            allLoaded = false;
+      }
+      if (allLoaded && !restored.isChainEditFadeHeld()) {
+        loaded = true;
+        break;
+      }
+      juce::Thread::sleep(20);
+    }
+  }
+  ASSERT_TRUE(loaded) << "restored IR block never finished reloading";
+  ASSERT_TRUE(restored.setBlockParam("blk-a", "mix", 1.0));
+  pumpAudio(restored, 1200, /*alreadyWarm=*/true);
+  letAudioGoIdle();
+
+  const auto [afterL, afterR] = processStereo(restored, impulse);
+
+  ASSERT_EQ(beforeL.size(), afterL.size());
+  float maxAbsDiff = 0.0f;
+  for (size_t i = 0; i < beforeL.size(); ++i) {
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(beforeL[i] - afterL[i]));
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(beforeR[i] - afterR[i]));
+  }
+  std::printf("[IrDecayTest] max |diff| before save vs after restore: %.9f\n",
+              static_cast<double>(maxAbsDiff));
+  EXPECT_LT(maxAbsDiff, 1e-4f)
+      << "restore didn't reapply the persisted envelope shape to the reloaded engine";
+}

--- a/test/src/predelay_tests.cpp
+++ b/test/src/predelay_tests.cpp
@@ -1,0 +1,131 @@
+// Pins that BlockPredelay only touches the wet path: at mix = 0 (pure dry),
+// engaging predelay must have zero audible effect, since dryScratch is
+// snapshotted before predelay ever runs (see Processor.cpp's per-block loop).
+#include "chain_test_helpers.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+
+namespace {
+constexpr int kBlock = 512;
+}  // namespace
+
+// Comparing block output directly against the raw synthetic input (as an
+// earlier version of this test did) is invalid: the global input gate
+// (Processor.cpp's inputGate.process(), applied before the chain even
+// starts) has its own envelope/threshold dynamics and is not a pure
+// passthrough for noise. The only valid comparison is two full processor
+// runs against *each other*, predelay off vs on, everything else identical
+// - isolating predelay's own contribution from the rest of the signal path.
+TEST(PredelayTest, DoesNotAffectDryPath) {
+  auto runWithPredelay = [](double predelayNormalized) {
+    ChainTestProcessor proc;
+    proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+    proc.prepareToPlay(kFs, kBlock);
+
+    seedStereoChains(proc, {"blk-a"}, {});
+    EXPECT_TRUE(waitForChainLoaded(proc)) << "IR block never finished loading from cache";
+
+    // Pure dry: mix = 0. Predelay is the only thing that differs between
+    // the two runs this is called for.
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "mix", 0.0));
+    EXPECT_TRUE(proc.setBlockParam("blk-a", "predelay", predelayNormalized));
+    letAudioGoIdle();
+
+    // mixSmoother (50ms) and wetFadeGain (25ms) only advance while
+    // processBlock actually runs - letAudioGoIdle() is wall-clock, not
+    // audio time. Warm up on real audio so both are fully converged before
+    // the comparison window (same margin DelaysOnlyTheWetPath proves
+    // sufficient below); discard this output.
+    constexpr int kWarmupBlocks = 15;
+    processStereo(proc, makeNoise(kWarmupBlocks * kBlock, 1111, 0.25f));
+
+    return processStereo(proc, makeNoise(20 * kBlock, 4242, 0.25f));
+  };
+
+  const auto [noDelayL, noDelayR] = runWithPredelay(0.0);
+  // Max predelay, so any leak into dry would be maximally audible/obvious.
+  const auto [maxDelayL, maxDelayR] = runWithPredelay(1.0);
+
+  ASSERT_EQ(noDelayL.size(), maxDelayL.size());
+  float maxAbsDiff = 0.0f;
+  for (size_t i = 0; i < noDelayL.size(); ++i) {
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(noDelayL[i] - maxDelayL[i]));
+    maxAbsDiff = std::max(maxAbsDiff, std::abs(noDelayR[i] - maxDelayR[i]));
+  }
+  // Not bit-exact: two independently-run instances through a chain with a
+  // noise gate, DC blocker and FFT convolver naturally accumulate ordinary
+  // floating-point rounding noise (unlike multicore_tests.cpp's bit-identical
+  // guarantee, which compares reordered ops on the *same* instance/inputs).
+  // A real predelay->dry leak would show up as a ~1-second-scale waveform
+  // shift, i.e. an amplitude-scale difference, not a rounding-floor one.
+  const float maxAbsDiffDb = juce::Decibels::gainToDecibels(maxAbsDiff, -300.0f);
+  std::printf("[PredelayTest] max |diff| between predelay=0 and predelay=max at mix=0: %.9f (%.1f dB)\n",
+              static_cast<double>(maxAbsDiff), static_cast<double>(maxAbsDiffDb));
+  EXPECT_LT(maxAbsDiff, 1e-4f) << "dry path diverges far more than floating-point rounding noise "
+                                  "explains - predelay is likely leaking into the dry signal";
+}
+
+TEST(PredelayTest, DelaysOnlyTheWetPath) {
+  ChainTestProcessor proc;
+  proc.setPlayConfigDetails(2, 2, kFs, kBlock);
+  proc.prepareToPlay(kFs, kBlock);
+
+  seedStereoChains(proc, {"blk-a"}, {});
+  ASSERT_TRUE(waitForChainLoaded(proc));
+
+  // Fully wet: output is exactly the convolved+predelayed signal, nothing
+  // dry blended in (mix=1 is also the short-cab load default, so no ramp
+  // to wait out there). Total buffer must comfortably fit
+  // warm-up + predelay + the cab IR's own onset, or the delayed onset
+  // never appears inside the window at all.
+  ASSERT_TRUE(proc.setBlockParam("blk-a", "mix", 1.0));
+  ASSERT_TRUE(proc.setBlockParam("blk-a", "predelay", 0.0));
+  letAudioGoIdle();
+
+  constexpr int kTotalBlocks = 90;   // 960ms @ 48k/512
+  // Fires at ~160ms: past both the 25ms wetFadeGain ramp and predelay's own
+  // ~80ms default live-change ramp (see BlockPredelay), so proc2's impulse
+  // below hits the fully-settled 200ms target, not a still-ramping value.
+  constexpr int kImpulseBlock = 15;
+  std::vector<float> impulse(static_cast<size_t>(kTotalBlocks * kBlock), 0.0f);
+  impulse[static_cast<size_t>(kImpulseBlock * kBlock)] = 1.0f;
+  const auto [noDelayL, noDelayR] = processStereo(proc, impulse);
+  juce::ignoreUnused(noDelayR);
+
+  // First sample where the convolved impulse response rises above the noise
+  // floor (the cab IR's own onset, no predelay).
+  auto firstAboveFloor = [](const std::vector<float>& v, float floor) {
+    for (size_t i = 0; i < v.size(); ++i)
+      if (std::abs(v[i]) > floor) return i;
+    return v.size();
+  };
+  const float floor = 1e-5f;
+  const size_t onsetNoDelay = firstAboveFloor(noDelayL, floor);
+  ASSERT_LT(onsetNoDelay, noDelayL.size()) << "IR produced no measurable output at all";
+
+  // Same impulse, now with 200ms predelay (9600 samples @ 48k): the wet
+  // onset should land ~200ms later than the undelayed case. predelay's own
+  // live-change ramp (~80ms default) is well clear of the impulse at
+  // kImpulseBlock (43ms in) since it starts ramping from the very first
+  // processBlock call, before the impulse fires.
+  ChainTestProcessor proc2;
+  proc2.setPlayConfigDetails(2, 2, kFs, kBlock);
+  proc2.prepareToPlay(kFs, kBlock);
+  seedStereoChains(proc2, {"blk-a"}, {});
+  ASSERT_TRUE(waitForChainLoaded(proc2));
+  ASSERT_TRUE(proc2.setBlockParam("blk-a", "mix", 1.0));
+  ASSERT_TRUE(proc2.setBlockParam("blk-a", "predelay", 0.2));  // 200ms
+  letAudioGoIdle();
+
+  const auto [delayedL, delayedR] = processStereo(proc2, impulse);
+  juce::ignoreUnused(delayedR);
+  const size_t onsetDelayed = firstAboveFloor(delayedL, floor);
+  ASSERT_LT(onsetDelayed, delayedL.size()) << "Predelayed IR produced no measurable output at all";
+
+  const size_t expectedShiftSamples = static_cast<size_t>(0.2 * kFs);
+  const size_t actualShift = onsetDelayed - onsetNoDelay;
+  EXPECT_NEAR(static_cast<double>(actualShift), static_cast<double>(expectedShiftSamples), 50.0)
+      << "onset(no predelay)=" << onsetNoDelay << " onset(200ms predelay)=" << onsetDelayed;
+}

--- a/ui/src/components/BlockEqView.tsx
+++ b/ui/src/components/BlockEqView.tsx
@@ -23,15 +23,14 @@ import { BODY_PADDING } from './chainLayout';
 import { rem } from '../hooks/useUiScale';
 import { EqSliders } from './EqSliders';
 import { SpectrumBackdrop } from './SpectrumBackdrop';
+import { EditableChip } from './EditableChip';
 import { HELP, bandTypeHelp, helpProps, pinHelp, unpinHelp } from './helpText';
 import {
   DISABLED_OPACITY,
   ICON_BOX_RADIUS,
   ICON_SIZE,
   MUTED,
-  FONT_MONO,
   SEGMENTED_TRACK,
-  SUBTLE,
   TEXT_BOX_HEIGHT,
   segmentedCellStyle,
   segmentedGroupStyle,
@@ -94,90 +93,6 @@ const GRID_LABELS: Record<number, string> = {
   2000: '2k',
   5000: '5k',
   10000: '10k',
-};
-
-/** Readout chip that doubles as text entry: click to type, Enter commits,
-    Escape cancels, blur commits (same conventions as the knobs). The value
-    area is a fixed width (sized to the longest possible reading) so the chip
-    never resizes while values change or while editing. */
-const EditableChip: React.FC<{
-  label: string;
-  text: string;
-  /** Prefill for the editor (number only, unit-free where possible). */
-  editText: string;
-  /** Fixed width of the value area in px: the widest reading the chip shows. */
-  valueWidth: number;
-  onCommit: (raw: string) => void;
-  disabled?: boolean;
-  /** One-line hint for the faceplate help readout (see helpText.ts). */
-  help?: string;
-  style?: React.CSSProperties;
-}> = ({ label, text, editText, valueWidth, onCommit, disabled = false, help, style }) => {
-  const [draft, setDraft] = useState<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const editing = draft !== null;
-
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
-
-  const commit = () => {
-    if (draft !== null && draft.trim() !== '') onCommit(draft);
-    setDraft(null);
-  };
-
-  return (
-    <div
-      {...(help && !disabled ? helpProps(help) : {})}
-      onClick={() => {
-        // Editing starts from an empty box (caret at the left) with the
-        // current value as placeholder; committing empty is a cancel.
-        if (!disabled && !editing) setDraft('');
-      }}
-      style={{ ...style, cursor: disabled || editing ? undefined : 'text' }}
-    >
-      <span style={{ fontSize: '12rem', fontFamily: FONT_MONO, color: SUBTLE }}>{label}</span>
-      {editing ? (
-        <input
-          ref={inputRef}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commit}
-          onKeyDown={(e) => {
-            e.stopPropagation();
-            if (e.key === 'Enter') commit();
-            else if (e.key === 'Escape') setDraft(null);
-          }}
-          inputMode="decimal"
-          placeholder={editText}
-          style={{
-            width: `${valueWidth}rem`,
-            background: 'transparent',
-            border: 'none',
-            color: '#ffffff',
-            fontSize: '12rem',
-            fontFamily: FONT_MONO,
-            textAlign: 'left',
-            outline: 'none',
-            padding: 0,
-          }}
-        />
-      ) : (
-        <span
-          style={{
-            width: `${valueWidth}rem`,
-            fontSize: '12rem',
-            fontFamily: FONT_MONO,
-            color: '#ffffff',
-            textAlign: 'left',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          {text}
-        </span>
-      )}
-    </div>
-  );
 };
 
 /** Parse a typed frequency: plain Hz ("800") or k-notation ("1.2k"). */

--- a/ui/src/components/ChainBlock.tsx
+++ b/ui/src/components/ChainBlock.tsx
@@ -15,7 +15,7 @@ import {
 import { ToneImage } from './GearIcon';
 import { rem } from '../hooks/useUiScale';
 import { KnobControl } from './KnobControl';
-import { gainDbScale } from './knobScale';
+import { gainDbScale, predelayMsScale } from './knobScale';
 import { BusyOverlay, LoadingDots } from './LoadingDots';
 import { ModelSelect } from './ModelSelect';
 import { RetryLoadBadge } from './RetryLoadBadge';
@@ -239,6 +239,7 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   const [inputGain, setInputGain] = useState(params.inputGain ?? 0.5);
   const [outputGain, setOutputGain] = useState(params.outputGain ?? 0.5);
   const [mix, setMix] = useState(params.mix ?? 1.0);
+  const [predelay, setPredelay] = useState(params.predelay ?? 0);
   const [isSwitchingModel, setIsSwitchingModel] = useState(false);
   const [showEq, setShowEq] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
@@ -283,6 +284,9 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   useEffect(() => {
     if (!knobDragRef.current) setMix(params.mix ?? 1.0);
   }, [params.mix]);
+  useEffect(() => {
+    if (!knobDragRef.current) setPredelay(params.predelay ?? 0);
+  }, [params.predelay]);
   useEffect(() => setEqOn(params.eq?.enabled ?? true), [params.eq?.enabled]);
   useEffect(() => setEqPre(params.eq?.pre ?? false), [params.eq?.pre]);
 
@@ -1096,6 +1100,35 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                       thumb="secondary"
                       defaultValue={defaultMix}
                       help={HELP.blockMix}
+                    />
+                  </div>
+                )}
+
+                {/* Predelay knob: IR blocks only, between Mix and the output rail */}
+                {!showInfo && !isNam && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'flex-end',
+                      flexShrink: 0,
+                    }}
+                  >
+                    <KnobControl
+                      label="Pre"
+                      value={predelay}
+                      onChange={(val) => {
+                        setPredelay(val);
+                        setParam('predelay', val);
+                      }}
+                      onDragStateChange={handleKnobDragState}
+                      size={KNOB_SIZE_SECONDARY}
+                      labelBottom={false}
+                      thumb="secondary"
+                      scale={predelayMsScale}
+                      defaultValue={0}
+                      help={HELP.blockPredelay}
                     />
                   </div>
                 )}

--- a/ui/src/components/ChainBlock.tsx
+++ b/ui/src/components/ChainBlock.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowLeft,
   ArrowLeftRight,
@@ -13,9 +13,22 @@ import {
   Trash2,
 } from './icons';
 import { ToneImage } from './GearIcon';
+import { WaveformDisplay } from './WaveformDisplay';
+import { IrEnvelopeGraph } from './IrEnvelopeGraph';
+import type { EnvelopePatch } from './IrEnvelopeGraph';
+import { useIrWaveform } from '../hooks/useIrWaveform';
 import { rem } from '../hooks/useUiScale';
 import { KnobControl } from './KnobControl';
-import { gainDbScale, predelayMsScale } from './knobScale';
+import { EditableChip } from './EditableChip';
+import {
+  gainDbScale,
+  predelayMsScale,
+  lengthMsScale,
+  attackLengthMsScale,
+  curveScale,
+  percentScale,
+} from './knobScale';
+import type { KnobScale } from './knobScale';
 import { BusyOverlay, LoadingDots } from './LoadingDots';
 import { ModelSelect } from './ModelSelect';
 import { RetryLoadBadge } from './RetryLoadBadge';
@@ -50,12 +63,14 @@ import { T3K_API } from '../t3k/config';
 import {
   BORDER,
   GRAY,
+  ICON_BOX_RADIUS,
   ICON_BOX_SIZE,
   ICON_SIZE,
   KNOB_SIZE_SECONDARY,
   FONT_MONO,
   MUTED,
   SEGMENTED_TRACK,
+  TEXT_BOX_HEIGHT,
   WHITE,
   segmentedCellStyle,
   segmentedGroupStyle,
@@ -70,6 +85,48 @@ const IMAGE_SIZE_INFO = 160;
 const RAIL_METER_HEIGHT = 160;
 /** Centers the normalize (=) chrome box on the Out knob. */
 const NORMALIZE_BUTTON_OFFSET = -(KNOB_SIZE_SECONDARY - ICON_BOX_SIZE) / 2;
+// IR blocks (!isNam) add a Delay knob beside In in the Input rail, widening
+// that rail (84rem: In 36 + gap 12 + Delay 36) past the Output rail (36rem:
+// just Out, since the normalize button is NAM-only) - a real ~48rem
+// asymmetry. A compensating spacer was tried in the Output rail to equalize
+// the two rails, but the row's Center column (flex:1) is what actually pays
+// for any width added to a fixed-width sibling: the spacer just shrank the
+// waveform/dropdown by the same 48rem, which cost more than the asymmetry it
+// fixed. True width parity would require *narrowing* the Input rail instead
+// (e.g. stacking Delay under In rather than beside it) - a real layout
+// change to a previously deliberate decision, not something to do as a
+// side effect of a symmetry pass. Left as-is for now.
+/** IR blocks (compact, non-Info view): wide waveform strip, full
+    Center-column width, replacing the square artwork. Sized to 100 (up from
+    an original 60) once the shaping row shrank from knobs to compact
+    EditableChips (see IrEnvelopeGraph.tsx) - that freed enough of the card's
+    fixed body height to make the graph meaningfully more legible without
+    touching BODY_HEIGHT. */
+const IR_WAVEFORM_HEIGHT = 100;
+/** Abstract SVG coordinate width for the strip - NOT a literal CSS pixel
+    width (the wrapper is width: 100%, and WaveformDisplay's viewBox stretches
+    to fit via preserveAspectRatio="none"), just needs to be self-consistent
+    for the mins/maxs/cut/decay math inside it. */
+const IR_WAVEFORM_WIDTH_UNITS = 600;
+
+/** Envelope shaping row's chip style - same track language as BlockEqView's
+    own Freq/Gain/Q chips (SEGMENTED_TRACK pill, TEXT_BOX_HEIGHT tall), just
+    tighter (smaller font, less padding): six chips with longer labels
+    (A Len/A Crv/D Len/D Lvl/D Crv) don't fit the card width at EQ's own
+    3-chip sizing. */
+const ENVELOPE_CHIP_FONT_SIZE = 10;
+const chipStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4rem',
+  height: `${TEXT_BOX_HEIGHT}rem`,
+  padding: '0 3rem',
+  borderRadius: rem(ICON_BOX_RADIUS),
+  border: 'none',
+  backgroundColor: SEGMENTED_TRACK,
+  boxSizing: 'border-box',
+  whiteSpace: 'nowrap',
+};
 
 /** Downloads / bookmarks / models count with a leading icon (same pattern as ToneBrowser). */
 const CountStat: React.FC<{ icon: React.ReactNode; value: number }> = ({ icon, value }) => (
@@ -240,6 +297,12 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   const [outputGain, setOutputGain] = useState(params.outputGain ?? 0.5);
   const [mix, setMix] = useState(params.mix ?? 1.0);
   const [predelay, setPredelay] = useState(params.predelay ?? 0);
+  const [initLevel, setInitLevel] = useState(params.initLevel ?? 1.0);
+  const [attackLength, setAttackLength] = useState(params.attackLength ?? 0.0);
+  const [attackCurve, setAttackCurve] = useState(params.attackCurve ?? 0.5);
+  const [decayLength, setDecayLength] = useState(params.decayLength ?? 1.0);
+  const [decayLevel, setDecayLevel] = useState(params.decayLevel ?? 1.0);
+  const [decayCurve, setDecayCurve] = useState(params.decayCurve ?? 0.5);
   const [isSwitchingModel, setIsSwitchingModel] = useState(false);
   const [showEq, setShowEq] = useState(false);
   const [showInfo, setShowInfo] = useState(false);
@@ -287,6 +350,24 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   useEffect(() => {
     if (!knobDragRef.current) setPredelay(params.predelay ?? 0);
   }, [params.predelay]);
+  useEffect(() => {
+    if (!knobDragRef.current) setInitLevel(params.initLevel ?? 1.0);
+  }, [params.initLevel]);
+  useEffect(() => {
+    if (!knobDragRef.current) setAttackLength(params.attackLength ?? 0.0);
+  }, [params.attackLength]);
+  useEffect(() => {
+    if (!knobDragRef.current) setAttackCurve(params.attackCurve ?? 0.5);
+  }, [params.attackCurve]);
+  useEffect(() => {
+    if (!knobDragRef.current) setDecayLength(params.decayLength ?? 1.0);
+  }, [params.decayLength]);
+  useEffect(() => {
+    if (!knobDragRef.current) setDecayLevel(params.decayLevel ?? 1.0);
+  }, [params.decayLevel]);
+  useEffect(() => {
+    if (!knobDragRef.current) setDecayCurve(params.decayCurve ?? 0.5);
+  }, [params.decayCurve]);
   useEffect(() => setEqOn(params.eq?.enabled ?? true), [params.eq?.enabled]);
   useEffect(() => setEqPre(params.eq?.pre ?? false), [params.eq?.pre]);
 
@@ -294,6 +375,94 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
     (param: BlockParamName, value: number | boolean) =>
       actions.setBlockParam(blockId, param, value),
     [actions, blockId]
+  );
+
+  // The envelope rebuilds the convolver off-thread (not a real-time
+  // smoother like setBlockParam's continuous params), so it isn't safe to
+  // fire at knob-drag rates - idle-debounced instead: the knobs and the
+  // waveform overlay (both driven by local state) update live on every drag
+  // frame, but the native rebuild only fires once movement pauses. All six
+  // values travel together in one call (like setBlockEqBand's whole-band
+  // updates), so each control's onChange passes its own new value plus the
+  // other five's current local state - a drag on one can't clobber
+  // another's in-flight value.
+  const envelopeCommitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (envelopeCommitTimerRef.current) clearTimeout(envelopeCommitTimerRef.current);
+    },
+    []
+  );
+  const commitEnvelope = useCallback(
+    (
+      nextInitLevel: number,
+      nextAttackLength: number,
+      nextAttackCurve: number,
+      nextDecayLength: number,
+      nextDecayLevel: number,
+      nextDecayCurve: number
+    ) => {
+      if (envelopeCommitTimerRef.current) clearTimeout(envelopeCommitTimerRef.current);
+      envelopeCommitTimerRef.current = setTimeout(() => {
+        envelopeCommitTimerRef.current = null;
+        actions.setBlockIrDecay(
+          blockId,
+          nextInitLevel,
+          nextAttackLength,
+          nextAttackCurve,
+          nextDecayLength,
+          nextDecayLevel,
+          nextDecayCurve
+        );
+      }, 400);
+    },
+    [actions, blockId]
+  );
+
+  // Graph-driven envelope edit (IrEnvelopeGraph): a patch carries only the
+  // axis/axes the dragged point moves (End moves two at once), merged over
+  // the current local values so a diagonal End drag commits as one call
+  // instead of two racing debounced ones.
+  const updateEnvelope = useCallback(
+    (patch: EnvelopePatch) => {
+      const next = {
+        initLevel: patch.initLevel ?? initLevel,
+        attackLength: patch.attackLength ?? attackLength,
+        attackCurve: patch.attackCurve ?? attackCurve,
+        decayLength: patch.decayLength ?? decayLength,
+        decayLevel: patch.decayLevel ?? decayLevel,
+        decayCurve: patch.decayCurve ?? decayCurve,
+      };
+      if (patch.initLevel !== undefined) setInitLevel(patch.initLevel);
+      if (patch.attackLength !== undefined) setAttackLength(patch.attackLength);
+      if (patch.attackCurve !== undefined) setAttackCurve(patch.attackCurve);
+      if (patch.decayLength !== undefined) setDecayLength(patch.decayLength);
+      if (patch.decayLevel !== undefined) setDecayLevel(patch.decayLevel);
+      if (patch.decayCurve !== undefined) setDecayCurve(patch.decayCurve);
+      commitEnvelope(
+        next.initLevel,
+        next.attackLength,
+        next.attackCurve,
+        next.decayLength,
+        next.decayLevel,
+        next.decayCurve
+      );
+    },
+    [initLevel, attackLength, attackCurve, decayLength, decayLevel, decayCurve, commitEnvelope]
+  );
+
+  // EditableChip commit for one envelope field: parses the typed display
+  // value (ms / % / curve units, matching that chip's own KnobScale) back to
+  // normalized 0..1 and routes it through the same updateEnvelope merge the
+  // graph uses, so a chip edit and a graph drag can never race each other.
+  const commitEnvelopeField = useCallback(
+    (key: keyof EnvelopePatch, scale: KnobScale, raw: string) => {
+      const parsed = Number.parseFloat(raw.replace(',', '.'));
+      if (!Number.isFinite(parsed)) return;
+      const normalized = Math.min(Math.max(scale.fromDisplay(parsed), 0), 1);
+      updateEnvelope({ [key]: normalized });
+    },
+    [updateEnvelope]
   );
 
   const handleToggleEnabled = useCallback(() => {
@@ -519,6 +688,39 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   const modelBusy = block.modelLoading || (!block.loaded && !block.loadFailed);
 
   const isNam = tone.format?.toLowerCase() === 'nam';
+  // POC: static waveform display replaces the artwork image for IR blocks
+  // only (see WaveformDisplay.tsx). `!isNam` in the gate skips the native
+  // fetch entirely for NAM blocks; falls back to the image while unfetched
+  // (fresh mount, still loading). activeModelId re-triggers the fetch on a
+  // dropdown/arrow model switch; modelLoading closes a real race on top of
+  // that (see useIrWaveform's doc comment).
+  const irWaveform = useIrWaveform(
+    blockId,
+    !isNam && block.loaded,
+    block.activeModelId,
+    block.modelLoading
+  );
+  // Decay Length is the TOTAL truncated length (the real "End" position) -
+  // normalized against *this* block's own detected content, same convention
+  // the old standalone Length knob always used - see knobScale.ts's
+  // lengthMsScale. Attack Length is a fraction *of that total*, not an
+  // independent length, so its own scale's max is Decay Length's current
+  // real-ms value (shrinks/grows live as Decay Length moves).
+  const decayLengthScale = useMemo(
+    () => lengthMsScale(block.irContentLengthMs),
+    [block.irContentLengthMs]
+  );
+  const attackLengthScale = useMemo(
+    () => attackLengthMsScale(decayLengthScale.toDisplay(decayLength)),
+    [decayLengthScale, decayLength]
+  );
+  // Derived for the waveform overlay: cutFraction is where the truncated
+  // content ends - Decay Length IS that fraction of the full content
+  // directly. attackFraction is where the Attack/Decay boundary sits
+  // *within* that truncated window (0..1) - Attack Length IS that fraction
+  // directly, matching envelopeDbAt's own fraction convention.
+  const cutFraction = decayLength;
+  const attackFractionWithinWindow = attackLength;
 
   // Calibration state (the gauge indicator + the normalize override). Only
   // meaningful while the user's input calibration setting is on: the gauge
@@ -819,40 +1021,94 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
               />
             ) : (
               <>
-                {/* Input rail: meter above In knob (Figma: gap 12). */}
+                {/* Input rail: meter above In knob (Figma: gap 12). IR blocks
+                  add a Delay knob alongside In (not below it - see the
+                  nested row) - the meter wrapper is knob-wide and the
+                  column left-aligns, so the meter stays centered over In
+                  specifically regardless of whether Delay widens the row to
+                  its right (same technique as the Output rail's meter
+                  staying pinned to Out despite the normalize button widening
+                  that row to its left, just mirrored to the opposite
+                  edge). */}
                 {!showInfo && (
                   <div
                     style={{
                       display: 'flex',
                       flexDirection: 'column',
-                      alignItems: 'center',
+                      alignItems: 'flex-start',
                       flexShrink: 0,
                       gap: '12rem',
                     }}
                   >
-                    <div style={{ flex: 1, display: 'flex', alignItems: 'center', minHeight: 0 }}>
+                    <div
+                      style={{
+                        flex: 1,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        minHeight: 0,
+                        width: `${KNOB_SIZE_SECONDARY}rem`,
+                      }}
+                    >
                       <BlockMeter meterId={meterId.blockIn(blockId)} length={RAIL_METER_HEIGHT} />
                     </div>
-                    <KnobControl
-                      label="In"
-                      value={inputGain}
-                      onChange={(val) => {
-                        setInputGain(val);
-                        setParam('inputGain', val);
+                    <div
+                      style={{
+                        display: 'flex',
+                        flexDirection: 'row',
+                        alignItems: 'flex-end',
+                        gap: '12rem',
                       }}
-                      onDragStateChange={handleKnobDragState}
-                      size={KNOB_SIZE_SECONDARY}
-                      labelBottom={false}
-                      thumb="secondary"
-                      scale={gainDbScale}
-                      defaultValue={0.5}
-                      help={HELP.blockIn}
-                    />
+                    >
+                      <KnobControl
+                        label="In"
+                        value={inputGain}
+                        onChange={(val) => {
+                          setInputGain(val);
+                          setParam('inputGain', val);
+                        }}
+                        onDragStateChange={handleKnobDragState}
+                        size={KNOB_SIZE_SECONDARY}
+                        labelBottom={false}
+                        thumb="secondary"
+                        scale={gainDbScale}
+                        defaultValue={0.5}
+                        help={HELP.blockIn}
+                      />
+                      {/* IR blocks only: predelay before the wet signal
+                        enters the convolver - a real-time DSP stage
+                        (BlockPredelay), not part of the off-thread envelope
+                        rebuild, so it stays a knob here rather than joining
+                        the shaping row's faders. */}
+                      {!isNam && (
+                        <KnobControl
+                          label="Delay"
+                          value={predelay}
+                          onChange={(val) => {
+                            setPredelay(val);
+                            setParam('predelay', val);
+                          }}
+                          onDragStateChange={handleKnobDragState}
+                          size={KNOB_SIZE_SECONDARY}
+                          labelBottom={false}
+                          thumb="secondary"
+                          scale={predelayMsScale}
+                          defaultValue={0}
+                          help={HELP.blockPredelay}
+                        />
+                      )}
+                    </div>
                   </div>
                 )}
 
-                {/* Center: image + tone info on top, model picker spanning full width.
-                  Info view keeps image + meta and drops the picker / knobs. */}
+                {/* Center: NAM blocks and the Info view (either format) keep
+                  the original image + full metadata layout. IR blocks
+                  outside Info view get a reworked, intentionally temporary
+                  v1 layout instead - see IR_WAVEFORM_HEIGHT's comment: a
+                  compact identity row, a wide short waveform strip, and the
+                  Start/End shaping rows, all ABOVE the model picker (which
+                  stays full-width at the bottom either way, matching the
+                  original layout). */}
                 <div
                   style={{
                     flex: 1,
@@ -860,205 +1116,436 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                     alignSelf: 'stretch',
                     display: 'flex',
                     flexDirection: 'column',
-                    justifyContent: showInfo ? 'flex-start' : 'space-between',
+                    gap: showInfo ? '24rem' : isNam ? '16rem' : '10rem',
+                    justifyContent: 'flex-start',
                   }}
                 >
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'row',
-                      alignItems: showInfo ? 'flex-start' : 'center',
-                      gap: '24rem',
-                      minWidth: 0,
-                    }}
-                  >
-                    {/* Tone image (gear glyph fallback, like the web's ToneCard) */}
-                    <div
-                      style={{
-                        position: 'relative',
-                        width: rem(showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE),
-                        height: rem(showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE),
-                        borderRadius: '8rem',
-                        overflow: 'hidden',
-                        flexShrink: 0,
-                      }}
-                    >
-                      <div
-                        style={{
-                          opacity: modelBusy || block.loadFailed ? 0.35 : 1,
-                          transition: 'opacity 0.2s ease',
-                          width: '100%',
-                          height: '100%',
-                        }}
-                      >
-                        <ToneImage
-                          src={tone.images?.[0]}
-                          alt={tone.title}
-                          gear={tone.gear}
-                          local={tone.local}
-                          boxSize={showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE}
-                        />
-                      </div>
-                      {(modelBusy || block.loadFailed) && (
-                        <div
-                          style={{
-                            position: 'absolute',
-                            inset: 0,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          {block.loadFailed ? (
-                            <RetryLoadBadge onRetry={() => actions.retryLoad(blockId)} />
-                          ) : (
-                            <LoadingDots />
-                          )}
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Tone info: title / gear+badge / counts / creator (Figma gaps).
-                      Info view appends description / makes / tags under this. */}
+                  {showInfo || isNam ? (
                     <div
                       style={{
                         display: 'flex',
-                        flexDirection: 'column',
-                        gap: showInfo ? '24rem' : '16rem',
+                        flexDirection: 'row',
+                        alignItems: showInfo ? 'flex-start' : 'center',
+                        gap: '24rem',
                         minWidth: 0,
-                        flex: 1,
                       }}
                     >
+                      {/* Tone image (gear glyph fallback, like the web's ToneCard) */}
+                      <div
+                        style={{
+                          position: 'relative',
+                          width: rem(showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE),
+                          height: rem(showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE),
+                          borderRadius: '8rem',
+                          overflow: 'hidden',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <div
+                          style={{
+                            opacity: modelBusy || block.loadFailed ? 0.35 : 1,
+                            transition: 'opacity 0.2s ease',
+                            width: '100%',
+                            height: '100%',
+                          }}
+                        >
+                          {!isNam && irWaveform ? (
+                            <WaveformDisplay
+                              mins={irWaveform.mins}
+                              maxs={irWaveform.maxs}
+                              width={showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE}
+                              height={showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE}
+                              contentLengthMs={block.irContentLengthMs}
+                              cutFraction={cutFraction}
+                              decay={{
+                                initLevel,
+                                attackCurve,
+                                attackFraction: attackFractionWithinWindow,
+                                decayLevel,
+                                decayCurve,
+                              }}
+                            />
+                          ) : (
+                            <ToneImage
+                              src={tone.images?.[0]}
+                              alt={tone.title}
+                              gear={tone.gear}
+                              local={tone.local}
+                              boxSize={showInfo ? IMAGE_SIZE_INFO : IMAGE_SIZE}
+                            />
+                          )}
+                        </div>
+                        {(modelBusy || block.loadFailed) && (
+                          <div
+                            style={{
+                              position: 'absolute',
+                              inset: 0,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            {block.loadFailed ? (
+                              <RetryLoadBadge onRetry={() => actions.retryLoad(blockId)} />
+                            ) : (
+                              <LoadingDots />
+                            )}
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Tone info: title / gear+badge / counts / creator (Figma gaps).
+                        Info view appends description / makes / tags under this. */}
                       <div
                         style={{
                           display: 'flex',
                           flexDirection: 'column',
-                          gap: '16rem',
+                          gap: showInfo ? '24rem' : '16rem',
                           minWidth: 0,
+                          flex: 1,
                         }}
                       >
                         <div
                           style={{
                             display: 'flex',
                             flexDirection: 'column',
-                            gap: '8rem',
+                            gap: '16rem',
                             minWidth: 0,
                           }}
                         >
-                          <span
-                            style={{
-                              fontSize: '18rem',
-                              color: WHITE,
-                              fontWeight: 700,
-                              lineHeight: 1.4,
-                              display: '-webkit-box',
-                              WebkitLineClamp: 2,
-                              WebkitBoxOrient: 'vertical',
-                              overflow: 'hidden',
-                            }}
-                          >
-                            {tone.title}
-                          </span>
-
                           <div
                             style={{
                               display: 'flex',
-                              flexDirection: 'row',
-                              alignItems: 'center',
-                              gap: '16rem',
+                              flexDirection: 'column',
+                              gap: '8rem',
+                              minWidth: 0,
                             }}
                           >
-                            {tone.gear && (
-                              <span style={{ fontSize: '14rem', color: MUTED, fontWeight: 400 }}>
-                                {gearLabel(tone.gear)}
-                              </span>
-                            )}
-                            {formatBadge && <FormatBadge label={formatBadge} a2={isNam} />}
-                          </div>
-                        </div>
-
-                        {!isLocal && (
-                          <div
-                            style={{
-                              display: 'flex',
-                              flexDirection: 'row',
-                              alignItems: 'center',
-                              gap: '24rem',
-                            }}
-                          >
-                            <CountStat
-                              icon={<Download size={16} />}
-                              value={tone.downloads_count ?? 0}
-                            />
-                            <BookmarkStat
-                              value={favoritesCount}
-                              favorited={favorited}
-                              onToggle={
-                                actions.authenticated
-                                  ? () => void handleToggleFavorite()
-                                  : undefined
-                              }
-                            />
-                            <CountStat icon={<FolderClosed size={16} />} value={modelsTotal ?? 0} />
-                          </div>
-                        )}
-
-                        {tone.user && (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: '12rem' }}>
-                            <div
+                            <span
                               style={{
-                                width: '32rem',
-                                height: '32rem',
-                                borderRadius: '50%',
+                                fontSize: '18rem',
+                                color: WHITE,
+                                fontWeight: 700,
+                                lineHeight: 1.4,
+                                display: '-webkit-box',
+                                WebkitLineClamp: 2,
+                                WebkitBoxOrient: 'vertical',
                                 overflow: 'hidden',
-                                flexShrink: 0,
                               }}
                             >
-                              <AvatarImage
-                                src={tone.user.avatar_url}
-                                alt={tone.user.username}
-                                size={32}
-                              />
-                            </div>
-                            <span style={{ fontSize: '14rem', color: GRAY, fontWeight: 400 }}>
-                              {tone.user.username}
-                              {tone.published_at && (
-                                <span style={{ color: MUTED }}>
-                                  {' '}
-                                  · {timeAgoShort(tone.published_at)}
+                              {tone.title}
+                            </span>
+
+                            <div
+                              style={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                alignItems: 'center',
+                                gap: '16rem',
+                              }}
+                            >
+                              {tone.gear && (
+                                <span style={{ fontSize: '14rem', color: MUTED, fontWeight: 400 }}>
+                                  {gearLabel(tone.gear)}
                                 </span>
                               )}
+                              {formatBadge && <FormatBadge label={formatBadge} a2={isNam} />}
+                            </div>
+                          </div>
+
+                          {!isLocal && (
+                            <div
+                              style={{
+                                display: 'flex',
+                                flexDirection: 'row',
+                                alignItems: 'center',
+                                gap: '24rem',
+                              }}
+                            >
+                              <CountStat
+                                icon={<Download size={16} />}
+                                value={tone.downloads_count ?? 0}
+                              />
+                              <BookmarkStat
+                                value={favoritesCount}
+                                favorited={favorited}
+                                onToggle={
+                                  actions.authenticated
+                                    ? () => void handleToggleFavorite()
+                                    : undefined
+                                }
+                              />
+                              <CountStat
+                                icon={<FolderClosed size={16} />}
+                                value={modelsTotal ?? 0}
+                              />
+                            </div>
+                          )}
+
+                          {tone.user && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '12rem' }}>
+                              <div
+                                style={{
+                                  width: '32rem',
+                                  height: '32rem',
+                                  borderRadius: '50%',
+                                  overflow: 'hidden',
+                                  flexShrink: 0,
+                                }}
+                              >
+                                <AvatarImage
+                                  src={tone.user.avatar_url}
+                                  alt={tone.user.username}
+                                  size={32}
+                                />
+                              </div>
+                              <span style={{ fontSize: '14rem', color: GRAY, fontWeight: 400 }}>
+                                {tone.user.username}
+                                {tone.published_at && (
+                                  <span style={{ color: MUTED }}>
+                                    {' '}
+                                    · {timeAgoShort(tone.published_at)}
+                                  </span>
+                                )}
+                              </span>
+                            </div>
+                          )}
+                        </div>
+
+                        {showInfo && (
+                          <BlockInfoPanel
+                            loading={infoLoading}
+                            error={infoError}
+                            onRetry={() => void fetchInfo(tone.id)}
+                            authenticated={actions.authenticated}
+                            onLogin={actions.login}
+                            tone={infoTone}
+                            pageUrl={tonePageUrl}
+                          />
+                        )}
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      {/* Compact identity row: title + format badge only.
+                        Stats/creator are dropped here for vertical room (this
+                        is a deliberately temporary v1 layout - see
+                        IR_WAVEFORM_HEIGHT's comment); they're still reachable
+                        via the Info panel. */}
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          gap: '4rem',
+                          minWidth: 0,
+                        }}
+                      >
+                        <span
+                          style={{
+                            fontSize: '16rem',
+                            color: WHITE,
+                            fontWeight: 700,
+                            lineHeight: 1.3,
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                          }}
+                        >
+                          {tone.title}
+                        </span>
+                        <div
+                          style={{
+                            display: 'flex',
+                            flexDirection: 'row',
+                            alignItems: 'center',
+                            gap: '12rem',
+                          }}
+                        >
+                          {tone.gear && (
+                            <span style={{ fontSize: '13rem', color: MUTED, fontWeight: 400 }}>
+                              {gearLabel(tone.gear)}
                             </span>
+                          )}
+                          {formatBadge && <FormatBadge label={formatBadge} a2={isNam} />}
+                        </div>
+                      </div>
+
+                      {/* Waveform: full Center-column width, short strip -
+                        the shape the future drag-to-shape v2 surface wants,
+                        and what frees the vertical room for the rows below. */}
+                      <div
+                        style={{
+                          position: 'relative',
+                          width: '100%',
+                          height: rem(IR_WAVEFORM_HEIGHT),
+                          borderRadius: '8rem',
+                          overflow: 'hidden',
+                          flexShrink: 0,
+                        }}
+                      >
+                        <div
+                          style={{
+                            opacity: modelBusy || block.loadFailed ? 0.35 : 1,
+                            transition: 'opacity 0.2s ease',
+                            width: '100%',
+                            height: '100%',
+                          }}
+                        >
+                          {irWaveform ? (
+                            <IrEnvelopeGraph
+                              mins={irWaveform.mins}
+                              maxs={irWaveform.maxs}
+                              width={IR_WAVEFORM_WIDTH_UNITS}
+                              height={IR_WAVEFORM_HEIGHT}
+                              contentLengthMs={block.irContentLengthMs}
+                              initLevel={initLevel}
+                              attackLength={attackLength}
+                              attackCurve={attackCurve}
+                              decayLength={decayLength}
+                              decayLevel={decayLevel}
+                              decayCurve={decayCurve}
+                              attackLengthScale={attackLengthScale}
+                              decayLengthScale={decayLengthScale}
+                              predelay={predelay}
+                              onChange={updateEnvelope}
+                              onDragStateChange={handleKnobDragState}
+                            />
+                          ) : (
+                            <div
+                              style={{
+                                width: '100%',
+                                height: '100%',
+                                backgroundColor: SEGMENTED_TRACK,
+                                borderRadius: '8rem',
+                              }}
+                            />
+                          )}
+                        </div>
+                        {(modelBusy || block.loadFailed) && (
+                          <div
+                            style={{
+                              position: 'absolute',
+                              inset: 0,
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                            }}
+                          >
+                            {block.loadFailed ? (
+                              <RetryLoadBadge onRetry={() => actions.retryLoad(blockId)} />
+                            ) : (
+                              <LoadingDots />
+                            )}
                           </div>
                         )}
                       </div>
 
-                      {showInfo && (
-                        <BlockInfoPanel
-                          loading={infoLoading}
-                          error={infoError}
-                          onRetry={() => void fetchInfo(tone.id)}
-                          authenticated={actions.authenticated}
-                          onLogin={actions.login}
-                          tone={infoTone}
-                          pageUrl={tonePageUrl}
+                      {/* Shaping row: Init/Attack (Length/Curve)/Decay
+                        (Length/Level/Curve) as precision-entry chips (same
+                        EditableChip pattern as the EQ's Freq/Gain/Q row) -
+                        the graph above is the by-ear control now, this row
+                        is for landing an exact value pointer-dragging can't
+                        reliably hit. Predelay stays a knob in the Input rail
+                        (it's a real-time DSP stage, not part of this
+                        off-thread envelope rebuild). Idle-debounced (see
+                        commitEnvelope) - chip commits and graph drags both
+                        route through updateEnvelope, so they can't race. */}
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'row',
+                          alignItems: 'center',
+                          justifyContent: 'space-between',
+                          gap: '6rem',
+                        }}
+                      >
+                        <EditableChip
+                          label="Init"
+                          text={percentScale.format(initLevel)}
+                          editText={percentScale.editText(initLevel)}
+                          valueWidth={32}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) => commitEnvelopeField('initLevel', percentScale, raw)}
+                          help={HELP.blockInitLevel}
+                          style={chipStyle}
                         />
-                      )}
-                    </div>
-                  </div>
+                        <EditableChip
+                          label="A Len"
+                          text={attackLengthScale.format(attackLength)}
+                          editText={attackLengthScale.editText(attackLength)}
+                          valueWidth={38}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) =>
+                            commitEnvelopeField('attackLength', attackLengthScale, raw)
+                          }
+                          help={HELP.blockAttackLength}
+                          style={chipStyle}
+                        />
+                        <EditableChip
+                          label="A Crv"
+                          text={curveScale.format(attackCurve)}
+                          editText={curveScale.editText(attackCurve)}
+                          valueWidth={32}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) => commitEnvelopeField('attackCurve', curveScale, raw)}
+                          help={HELP.blockAttackCurve}
+                          style={chipStyle}
+                        />
+                        <EditableChip
+                          label="D Len"
+                          text={decayLengthScale.format(decayLength)}
+                          editText={decayLengthScale.editText(decayLength)}
+                          valueWidth={38}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) =>
+                            commitEnvelopeField('decayLength', decayLengthScale, raw)
+                          }
+                          help={HELP.blockDecayLength}
+                          style={chipStyle}
+                        />
+                        <EditableChip
+                          label="D Lvl"
+                          text={percentScale.format(decayLevel)}
+                          editText={percentScale.editText(decayLevel)}
+                          valueWidth={32}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) => commitEnvelopeField('decayLevel', percentScale, raw)}
+                          help={HELP.blockDecayLevel}
+                          style={chipStyle}
+                        />
+                        <EditableChip
+                          label="D Crv"
+                          text={curveScale.format(decayCurve)}
+                          editText={curveScale.editText(decayCurve)}
+                          valueWidth={32}
+                          fontSize={ENVELOPE_CHIP_FONT_SIZE}
+                          onCommit={(raw) => commitEnvelopeField('decayCurve', curveScale, raw)}
+                          help={HELP.blockDecayCurve}
+                          style={chipStyle}
+                        />
+                      </div>
+                    </>
+                  )}
 
-                  {/* Switching catalog models re-downloads through native with
-                  a Bearer token, so the picker is inert while signed out.
-                  The wrapper carries the cursor + hint, as the select itself
-                  is pointer-events: none when disabled. Local switches read
-                  the stash: no auth, and the picker always shows (the
-                  dropped file names are the block's provenance). */}
+                  {/* Model picker: full width, below everything - matches the
+                    original layout. marginTop: auto absorbs the Center
+                    column's leftover height (identity/waveform/shaping-row
+                    don't fill the fixed body height on their own) so this
+                    stays bottom-aligned with the In/Delay/Mix/Out rails'
+                    knobs instead of floating above them. Switching catalog
+                    models re-downloads through native with a Bearer token,
+                    so the picker is inert while signed out - the wrapper
+                    carries the cursor + hint, as the select itself is
+                    pointer-events: none when disabled. Local switches read
+                    the stash: no auth, and the picker always shows (the
+                    dropped file names are the block's provenance). */}
                   {!showInfo && (
                     <div
                       {...(!isLocal && !actions.authenticated
                         ? helpProps(HELP.modelSelectSignedOut)
                         : {})}
                       style={{
+                        marginTop: 'auto',
                         cursor: isLocal || actions.authenticated ? 'default' : 'not-allowed',
                       }}
                     >
@@ -1104,35 +1591,6 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                   </div>
                 )}
 
-                {/* Predelay knob: IR blocks only, between Mix and the output rail */}
-                {!showInfo && !isNam && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      flexDirection: 'column',
-                      alignItems: 'center',
-                      justifyContent: 'flex-end',
-                      flexShrink: 0,
-                    }}
-                  >
-                    <KnobControl
-                      label="Pre"
-                      value={predelay}
-                      onChange={(val) => {
-                        setPredelay(val);
-                        setParam('predelay', val);
-                      }}
-                      onDragStateChange={handleKnobDragState}
-                      size={KNOB_SIZE_SECONDARY}
-                      labelBottom={false}
-                      thumb="secondary"
-                      scale={predelayMsScale}
-                      defaultValue={0}
-                      help={HELP.blockPredelay}
-                    />
-                  </div>
-                )}
-
                 {/* Output rail: meter above Out (+ optional normalize). The rail
                 right-aligns and the meter wrapper is knob-wide, so the meter
                 stays centered over the Out knob whether or not the normalize
@@ -1164,7 +1622,7 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                         display: 'flex',
                         flexDirection: 'row',
                         alignItems: 'flex-end',
-                        gap: '10rem',
+                        gap: '12rem',
                       }}
                     >
                       {isNam && showNormalizeControl && (

--- a/ui/src/components/EditableChip.tsx
+++ b/ui/src/components/EditableChip.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { helpProps } from './helpText';
+import { FONT_MONO, SUBTLE } from './theme';
+
+/** Readout chip that doubles as text entry: click to type, Enter commits,
+    Escape cancels, blur commits (same conventions as the knobs). The value
+    area is a fixed width (sized to the longest possible reading) so the chip
+    never resizes while values change or while editing. Shared by BlockEqView
+    (Freq/Gain/Q) and ChainBlock's IR envelope row (Init/A Len/A Crv/D Len/
+    D Lvl/D Crv) - the "graph/sliders for by-ear, chip for exact value"
+    split used by both editors. */
+export const EditableChip: React.FC<{
+  label: string;
+  text: string;
+  /** Prefill for the editor (number only, unit-free where possible). */
+  editText: string;
+  /** Fixed width of the value area in px: the widest reading the chip shows. */
+  valueWidth: number;
+  onCommit: (raw: string) => void;
+  disabled?: boolean;
+  /** One-line hint for the faceplate help readout (see helpText.ts). */
+  help?: string;
+  style?: React.CSSProperties;
+  /** Label/value font size in rem units. Defaults to the EQ chips' 12; the
+      IR envelope row (six chips, longer labels than EQ's Freq/Gain/Q) passes
+      a smaller size so the row fits the card width. */
+  fontSize?: number;
+}> = ({
+  label,
+  text,
+  editText,
+  valueWidth,
+  onCommit,
+  disabled = false,
+  help,
+  style,
+  fontSize = 12,
+}) => {
+  const [draft, setDraft] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const editing = draft !== null;
+
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const commit = () => {
+    if (draft !== null && draft.trim() !== '') onCommit(draft);
+    setDraft(null);
+  };
+
+  return (
+    <div
+      {...(help && !disabled ? helpProps(help) : {})}
+      onClick={() => {
+        // Editing starts from an empty box (caret at the left) with the
+        // current value as placeholder; committing empty is a cancel.
+        if (!disabled && !editing) setDraft('');
+      }}
+      style={{ ...style, cursor: disabled || editing ? undefined : 'text' }}
+    >
+      <span style={{ fontSize: `${fontSize}rem`, fontFamily: FONT_MONO, color: SUBTLE }}>
+        {label}
+      </span>
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            e.stopPropagation();
+            if (e.key === 'Enter') commit();
+            else if (e.key === 'Escape') setDraft(null);
+          }}
+          inputMode="decimal"
+          placeholder={editText}
+          style={{
+            width: `${valueWidth}rem`,
+            background: 'transparent',
+            border: 'none',
+            color: '#ffffff',
+            fontSize: `${fontSize}rem`,
+            fontFamily: FONT_MONO,
+            textAlign: 'left',
+            outline: 'none',
+            padding: 0,
+          }}
+        />
+      ) : (
+        <span
+          style={{
+            width: `${valueWidth}rem`,
+            fontSize: `${fontSize}rem`,
+            fontFamily: FONT_MONO,
+            color: '#ffffff',
+            textAlign: 'left',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {text}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/ui/src/components/IrEnvelopeGraph.tsx
+++ b/ui/src/components/IrEnvelopeGraph.tsx
@@ -220,18 +220,21 @@ export const IrEnvelopeGraph: React.FC<{
         return { x: (peakX + cutX) / 2, y: endY / 2 };
     }
   };
+  // Value only, no parameter-name prefix (e.g. "-6dB", not "Init -6dB") -
+  // besides being less cluttered, the shorter text also gives the top-edge
+  // clipping fix above more effective margin to work with.
   const readoutLabel = (target: DragTarget): string => {
     switch (target) {
       case 'init':
-        return `Init ${percentScale.format(initLevel)}`;
+        return percentScale.format(initLevel);
       case 'peak':
-        return `Attack ${attackLengthScale.format(attackLength)}`;
+        return attackLengthScale.format(attackLength);
       case 'end':
-        return `Decay ${decayLengthScale.format(decayLength)} · ${percentScale.format(decayLevel)}`;
+        return `${decayLengthScale.format(decayLength)} · ${percentScale.format(decayLevel)}`;
       case 'attack':
-        return `A Curve ${curveScale.format(attackCurve)}`;
+        return curveScale.format(attackCurve);
       case 'decay':
-        return `D Curve ${curveScale.format(decayCurve)}`;
+        return curveScale.format(decayCurve);
     }
   };
 

--- a/ui/src/components/IrEnvelopeGraph.tsx
+++ b/ui/src/components/IrEnvelopeGraph.tsx
@@ -1,0 +1,635 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { BRAND_YELLOW, BRAND_RED, MUTED, WHITE } from './theme';
+import { dbToLevel, levelToDb } from './decayEnvelope';
+import {
+  buildDecayFillPath,
+  buildDecaySegments,
+  buildWaveformPath,
+  dbToY,
+  formatContentLength,
+  yToDb,
+} from './WaveformDisplay';
+import { curveScale, percentScale } from './knobScale';
+import type { KnobScale } from './knobScale';
+import { HELP, helpProps, pinHelp, unpinHelp } from './helpText';
+
+/**
+ * Interactive replacement for WaveformDisplay in the IR block's main editor
+ * (ChainBlock.tsx) - Phase 2 of the envelope shaping feature. Draws the same
+ * backdrop/curve WaveformDisplay does (shared helpers, pixel-identical), but
+ * the three curve control points (Init/Peak/End) are draggable directly on
+ * the graph instead of via the separate fader row.
+ *
+ * Fixed-window philosophy, matching the original Length knob and
+ * WaveformDisplay: the backdrop (waveform, axis) never rescales - only the
+ * overlay (cut line, curve, points) moves within it. Dragging End's X slides
+ * along that same fixed axis. Because Peak's on-screen x is
+ * attackFraction * decayLength * width (a fraction of a fraction), dragging
+ * End alone visibly moves Peak's on-screen position even though Peak's own
+ * parameter (attackLength) didn't change - that's correct, not a bug.
+ *
+ * Curve-line dragging (Init->Peak, Peak->End): a vertical drag on either
+ * segment bows that segment's own Curve parameter. The sign of "drag down ->
+ * curve increases or decreases" flips between the two segments, and this is
+ * intentional, not a bug - see decayCurveExponent's own doc comment. Init->
+ * Peak *rises* (init level up to unity), so increasing its curve exponent
+ * (k, via decayCurveExponent) shrinks fraction^k at any fixed fraction<1,
+ * pulling the sampled value *down* toward its start (a lower, more
+ * attenuated dB - visually a downward bow); dragging the line down should
+ * therefore *increase* attackCurve. Peak->End *falls* (unity down to decay
+ * level), where (to-from) is negative, so the same shrinking fraction^k
+ * makes the sampled value *less* negative (less attenuated - visually an
+ * upward bow) as curve increases; dragging the line down should therefore
+ * *decrease* decayCurve. Both reduce to the same rule stated once, in
+ * `handlePointerMove` below, as a per-segment sign.
+ *
+ * Hover rings, the floating readout, cursor states, Shift-fine and
+ * Alt-click-reset all follow this file's own established conventions rather
+ * than inventing new ones: Shift-fine and the readout's show/hold timing
+ * mirror EnvelopeFader/KnobControl; Alt-click-reset and the hover ring mirror
+ * BlockEqView's dot handling exactly (down to reading modifier state off the
+ * pointer event itself rather than separate keydown/keyup listeners, since
+ * BlockEqView's own comment elsewhere in this codebase notes the plugin
+ * webview doesn't reliably deliver bare-modifier key events).
+ */
+
+export interface EnvelopePatch {
+  initLevel?: number;
+  attackLength?: number;
+  attackCurve?: number;
+  decayLength?: number;
+  decayLevel?: number;
+  decayCurve?: number;
+}
+
+type DragTarget = 'init' | 'peak' | 'end' | 'attack' | 'decay';
+
+const clamp = (v: number, lo: number, hi: number) => Math.min(Math.max(v, lo), hi);
+
+/** Same hold as EnvelopeFader/KnobControl's own drag readouts. */
+const READOUT_HOLD_MS = 250;
+
+const targetHelp = (target: DragTarget): string => {
+  switch (target) {
+    case 'init':
+      return HELP.envelopeInitPoint;
+    case 'peak':
+      return HELP.envelopePeakPoint;
+    case 'end':
+      return HELP.envelopeEndPoint;
+    case 'attack':
+      return HELP.envelopeAttackCurve;
+    case 'decay':
+      return HELP.envelopeDecayCurve;
+  }
+};
+
+/** "Nice" axis-tick step (the standard 1-2-5-times-a-power-of-ten sequence
+    chart libraries use) for a background time grid spanning `totalMs`,
+    aiming for roughly `targetTicks` gridlines. */
+const niceGridStepMs = (totalMs: number, targetTicks = 6): number => {
+  if (!Number.isFinite(totalMs) || totalMs <= 0) return 0;
+  const rough = totalMs / targetTicks;
+  const magnitude = Math.pow(10, Math.floor(Math.log10(rough)));
+  const residual = rough / magnitude;
+  const step = residual < 1.5 ? 1 : residual < 3.5 ? 2 : residual < 7.5 ? 5 : 10;
+  return step * magnitude;
+};
+
+/** Points sit exactly on the content's true edges (Init at x=0, Peak at
+    y=0/unity, End's x/y reaching the same edges at extreme values) - their
+    hit-circle would be half-clipped by a viewBox that ends exactly there.
+    The viewBox is padded by this on every side so the full circle always has
+    room; content (waveform/curve/points) keeps its true 0..width/0..height
+    coordinates unchanged, it just no longer sits flush against the SVG's own
+    edge. */
+const HIT_RADIUS = 14;
+const EDGE_PAD = HIT_RADIUS + 2;
+
+export const IrEnvelopeGraph: React.FC<{
+  mins: number[];
+  maxs: number[];
+  width: number;
+  height: number;
+  contentLengthMs?: number;
+  initLevel: number;
+  attackLength: number;
+  attackCurve: number;
+  decayLength: number;
+  decayLevel: number;
+  decayCurve: number;
+  /** Dynamic per-block scales (see knobScale.ts) - only needed here for the
+      floating readout's text; the graph's own geometry works in plain
+      normalized 0..1 fractions regardless. */
+  attackLengthScale: KnobScale;
+  decayLengthScale: KnobScale;
+  /** Normalized Predelay (BlockParams.predelay) - display-only here (a
+      left-edge line, shown only when > 0, mirroring the cut line's own
+      treatment); the Delay knob in the Input rail is still the only way to
+      change it. Not part of the envelope patch/onChange - a separate,
+      real-time DSP stage. */
+  predelay: number;
+  /** Called on every pointermove with just the axis/axes that point moves
+      (Init: initLevel only; Peak: attackLength only; End: both decayLength
+      and decayLevel together, so a diagonal drag commits as one native
+      rebuild rather than two racing ones). */
+  onChange: (patch: EnvelopePatch) => void;
+  onDragStateChange?: (dragging: boolean) => void;
+}> = ({
+  mins,
+  maxs,
+  width,
+  height,
+  contentLengthMs,
+  initLevel,
+  attackLength,
+  attackCurve,
+  decayLength,
+  decayLevel,
+  decayCurve,
+  attackLengthScale,
+  decayLengthScale,
+  predelay,
+  onChange,
+  onDragStateChange,
+}) => {
+  const graphRef = useRef<SVGSVGElement | null>(null);
+  const dragStateRef = useRef<{ target: DragTarget; lastX: number; lastY: number } | null>(null);
+  // Mirrors dragStateRef.current?.target, but as state so it can drive
+  // re-renders (ring, cursor, readout visibility) - the ref alone is enough
+  // for the pointer math, which needs no re-render.
+  const [dragTarget, setDragTarget] = useState<DragTarget | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<DragTarget | null>(null);
+  // Which target's floating readout is showing - set on grab, cleared only
+  // once the post-release hold timer expires (unlike dragTarget, which
+  // clears immediately on release), so the readout lingers on the value the
+  // user just landed on rather than vanishing the instant they let go.
+  const [readoutTarget, setReadoutTarget] = useState<DragTarget | null>(null);
+  const readoutHoldTimerRef = useRef<number | null>(null);
+  useEffect(
+    () => () => {
+      if (readoutHoldTimerRef.current !== null) window.clearTimeout(readoutHoldTimerRef.current);
+    },
+    []
+  );
+
+  const waveformPath = buildWaveformPath(mins, maxs, width, height);
+
+  // Background time grid (Space Designer-style reference lines) across the
+  // fixed window's full real-world span - contentLengthMs is what x=width
+  // itself represents, regardless of where the cut line currently sits.
+  const gridStepMs = niceGridStepMs(contentLengthMs ?? 0);
+  const gridLinesX: number[] = [];
+  if (gridStepMs > 0 && contentLengthMs) {
+    for (let ms = gridStepMs; ms < contentLengthMs; ms += gridStepMs) {
+      gridLinesX.push((ms / contentLengthMs) * width);
+    }
+  }
+
+  const cutFraction = clamp(decayLength, 0, 1);
+  const cutX = width * cutFraction;
+  const attackFraction = clamp(attackLength, 0, 1);
+
+  const hasDecay = initLevel !== 1 || decayLevel !== 1;
+  const decayParams = { initLevel, attackCurve, attackFraction, decayLevel, decayCurve };
+  const segments = hasDecay ? buildDecaySegments(decayParams, cutX, height) : null;
+  // Fill is zero-area (invisible) exactly when the curve sits flush on the
+  // 0dB ceiling the whole way (the flat/no-op case) - a direct geometric
+  // consequence of "area under the curve", not a separate condition.
+  const fillPath = hasDecay ? buildDecayFillPath(decayParams, cutX, height) : '';
+
+  const initY = dbToY(levelToDb(initLevel), height);
+  const peakX = cutX * attackFraction;
+  const endY = dbToY(levelToDb(decayLevel), height);
+
+  // Floating readout: anchored at the point's own coordinates for Init/Peak/
+  // End, or the segment's straight-line midpoint for Attack/Decay curve (a
+  // fixed, always-derivable position - unlike the live pointer, it needs no
+  // extra state to track).
+  const readoutAnchor = (target: DragTarget): { x: number; y: number } => {
+    switch (target) {
+      case 'init':
+        return { x: 0, y: initY };
+      case 'peak':
+        return { x: peakX, y: 0 };
+      case 'end':
+        return { x: cutX, y: endY };
+      case 'attack':
+        return { x: peakX / 2, y: initY / 2 };
+      case 'decay':
+        return { x: (peakX + cutX) / 2, y: endY / 2 };
+    }
+  };
+  const readoutLabel = (target: DragTarget): string => {
+    switch (target) {
+      case 'init':
+        return `Init ${percentScale.format(initLevel)}`;
+      case 'peak':
+        return `Attack ${attackLengthScale.format(attackLength)}`;
+      case 'end':
+        return `Decay ${decayLengthScale.format(decayLength)} · ${percentScale.format(decayLevel)}`;
+      case 'attack':
+        return `A Curve ${curveScale.format(attackCurve)}`;
+      case 'decay':
+        return `D Curve ${curveScale.format(decayCurve)}`;
+    }
+  };
+
+  // Pixel <-> parameter-unit conversions, all going through the same dB
+  // domain the curve itself is plotted in (see dbToY/yToDb's own comment).
+  const yToLevel = useCallback((y: number) => dbToLevel(yToDb(y, height)), [height]);
+  const xToAttackFraction = useCallback((x: number) => (cutX > 0 ? x / cutX : 0), [cutX]);
+  const xToDecayLength = useCallback((x: number) => x / width, [width]);
+
+  // Rect spans the padded viewBox (preserveAspectRatio="none" stretches it
+  // exactly to the element's box), so a fraction across rect maps linearly
+  // to [-EDGE_PAD, width+EDGE_PAD] / [-EDGE_PAD, height+EDGE_PAD], not to
+  // [0, width]/[0, height] directly.
+  const graphPointFromEvent = useCallback(
+    (e: PointerEvent | React.PointerEvent) => {
+      const rect = graphRef.current?.getBoundingClientRect();
+      if (!rect) return { x: 0, y: 0 };
+      return {
+        x: ((e.clientX - rect.left) / rect.width) * (width + EDGE_PAD * 2) - EDGE_PAD,
+        y: ((e.clientY - rect.top) / rect.height) * (height + EDGE_PAD * 2) - EDGE_PAD,
+      };
+    },
+    [width, height]
+  );
+
+  // Point reset (Init/Peak/End only, not the curve segments): Alt/Option-
+  // click and double-click both trigger it - the pointerdown handler for the
+  // altKey case, and a dedicated onDoubleClick for the click case (points
+  // only; curve segments carry neither).
+  const resetTarget = useCallback(
+    (target: DragTarget) => {
+      if (target === 'init') onChange({ initLevel: 1.0 });
+      else if (target === 'peak') onChange({ attackLength: 0.0 });
+      else if (target === 'end') onChange({ decayLength: 1.0, decayLevel: 1.0 });
+      else if (target === 'attack') onChange({ attackCurve: 0.5 });
+      else onChange({ decayCurve: 0.5 });
+    },
+    [onChange]
+  );
+
+  // Alt/Option-click resets without engaging a drag - mirrors BlockEqView's
+  // resetBand-then-early-return.
+  const handlePointerDown = useCallback(
+    (target: DragTarget) => (e: React.PointerEvent<SVGCircleElement | SVGPathElement>) => {
+      e.preventDefault();
+      if (e.altKey) {
+        resetTarget(target);
+        return;
+      }
+      e.currentTarget.setPointerCapture(e.pointerId);
+      const { x, y } = graphPointFromEvent(e);
+      dragStateRef.current = { target, lastX: x, lastY: y };
+      setDragTarget(target);
+      if (readoutHoldTimerRef.current !== null) {
+        window.clearTimeout(readoutHoldTimerRef.current);
+        readoutHoldTimerRef.current = null;
+      }
+      setReadoutTarget(target);
+      pinHelp(targetHelp(target));
+      onDragStateChange?.(true);
+    },
+    [graphPointFromEvent, resetTarget, onDragStateChange]
+  );
+
+  // Delta-based (not absolute pointer position), each delta computed in the
+  // target parameter's own unit space rather than raw pixels - mirrors
+  // BlockEqView's dot dragging, and (unlike a raw-pixel delta) stays correct
+  // if the pixel<->unit mapping is ever non-linear. Curve deltas are the one
+  // exception: Curve is already a plain linear 0..1 shape parameter with no
+  // natural pixel-domain unit of its own (mirroring how BlockEqView's own Q
+  // drag uses an arbitrary tuned constant rather than a unit conversion), so
+  // a raw dY fraction of the graph height is used directly.
+  const handlePointerMove = useCallback(
+    (target: DragTarget) => (e: React.PointerEvent<SVGCircleElement | SVGPathElement>) => {
+      const drag = dragStateRef.current;
+      if (!drag || drag.target !== target) return;
+      const { x, y } = graphPointFromEvent(e);
+      const fine = e.shiftKey ? 1 / 8 : 1;
+
+      if (target === 'init') {
+        const dLevel = (yToLevel(y) - yToLevel(drag.lastY)) * fine;
+        onChange({ initLevel: clamp(initLevel + dLevel, 0, 1) });
+      } else if (target === 'peak') {
+        const dFraction = (xToAttackFraction(x) - xToAttackFraction(drag.lastX)) * fine;
+        onChange({ attackLength: clamp(attackLength + dFraction, 0, 1) });
+      } else if (target === 'end') {
+        const dLength = (xToDecayLength(x) - xToDecayLength(drag.lastX)) * fine;
+        const dLevel = (yToLevel(y) - yToLevel(drag.lastY)) * fine;
+        onChange({
+          decayLength: clamp(decayLength + dLength, 0, 1),
+          decayLevel: clamp(decayLevel + dLevel, 0, 1),
+        });
+      } else {
+        // See this component's own doc comment for why the sign flips
+        // between a rising (attack) and falling (decay) segment.
+        const sign = target === 'attack' ? 1 : -1;
+        const dCurve = (sign * (y - drag.lastY) * fine) / height;
+        if (target === 'attack') {
+          onChange({ attackCurve: clamp(attackCurve + dCurve, 0, 1) });
+        } else {
+          onChange({ decayCurve: clamp(decayCurve + dCurve, 0, 1) });
+        }
+      }
+      drag.lastX = x;
+      drag.lastY = y;
+    },
+    [
+      graphPointFromEvent,
+      yToLevel,
+      xToAttackFraction,
+      xToDecayLength,
+      height,
+      initLevel,
+      attackLength,
+      attackCurve,
+      decayLength,
+      decayLevel,
+      decayCurve,
+      onChange,
+    ]
+  );
+
+  const handlePointerUp = useCallback(() => {
+    const target = dragStateRef.current?.target;
+    if (!target) return;
+    dragStateRef.current = null;
+    setDragTarget(null);
+    unpinHelp(targetHelp(target));
+    if (readoutHoldTimerRef.current !== null) window.clearTimeout(readoutHoldTimerRef.current);
+    readoutHoldTimerRef.current = window.setTimeout(() => setReadoutTarget(null), READOUT_HOLD_MS);
+    onDragStateChange?.(false);
+  }, [onDragStateChange]);
+
+  const lengthLabel = formatContentLength(contentLengthMs ?? NaN);
+  const labelFontSize = Math.max(9, height * 0.16);
+  const labelPaddingX = labelFontSize * 0.55;
+  const labelPaddingY = labelFontSize * 0.3;
+  const labelMargin = labelFontSize * 0.5;
+  const labelWidth = lengthLabel ? lengthLabel.length * labelFontSize * 0.6 + labelPaddingX * 2 : 0;
+  const labelHeight = labelFontSize + labelPaddingY * 2;
+  const gradientId = 'ir-envelope-graph-gradient';
+
+  const hitCircle = (target: DragTarget, cx: number, cy: number) => (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={HIT_RADIUS}
+      fill="transparent"
+      style={{ cursor: dragTarget === target ? 'grabbing' : 'grab', touchAction: 'none' }}
+      {...helpProps(targetHelp(target))}
+      onPointerEnter={() => setHoverTarget(target)}
+      onPointerLeave={() => setHoverTarget((t) => (t === target ? null : t))}
+      onPointerDown={handlePointerDown(target)}
+      onPointerMove={handlePointerMove(target)}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+      onDoubleClick={() => resetTarget(target)}
+    />
+  );
+
+  /** EQ's r=9 selection-ring outline, shown while hovered or dragging. */
+  const ring = (target: DragTarget, cx: number, cy: number) =>
+    (hoverTarget === target || dragTarget === target) && (
+      <circle
+        cx={cx}
+        cy={cy}
+        r={9}
+        fill="none"
+        stroke="#ffffff"
+        strokeWidth={1.5}
+        opacity={0.9}
+        style={{ pointerEvents: 'none' }}
+      />
+    );
+
+  // pointerEvents: 'none' - purely decorative, sits on top of (and would
+  // otherwise steal clicks from) its own larger hitCircle underneath; they're
+  // siblings, not parent/child, so a captured click on this circle would
+  // dead-end here rather than bubbling down to the hit target.
+  const dot = (cx: number, cy: number) => (
+    <circle
+      cx={cx}
+      cy={cy}
+      r={4.5}
+      fill={WHITE}
+      stroke="#000000"
+      strokeWidth={1.25}
+      style={{ pointerEvents: 'none' }}
+    />
+  );
+
+  /** Invisible thick path under the visible curve segment - carries the
+      curve-line drag. `pointerEvents: 'stroke'` (fill is always none) means
+      only the rendered 14-unit-wide stroke itself is hit-tested, not the
+      empty area a filled shape covering the same bounding box would
+      include. */
+  const segmentHitPath = (target: 'attack' | 'decay', d: string) => (
+    <path
+      d={d}
+      fill="none"
+      stroke="transparent"
+      strokeWidth={14}
+      style={{ pointerEvents: 'stroke', cursor: 'ns-resize', touchAction: 'none' }}
+      {...helpProps(targetHelp(target))}
+      onPointerEnter={() => setHoverTarget(target)}
+      onPointerLeave={() => setHoverTarget((t) => (t === target ? null : t))}
+      onPointerDown={handlePointerDown(target)}
+      onPointerMove={handlePointerMove(target)}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerUp}
+    />
+  );
+
+  // HTML overlay (not SVG text) for the readout so its font isn't stretched
+  // by the SVG's non-uniform preserveAspectRatio="none" scaling. Position is
+  // expressed as a percentage of the padded viewBox, which the SVG element
+  // fills exactly (width/height 100%), so it lines up with the anchor
+  // regardless of the card's actual rendered size.
+  const viewBoxWidth = width + EDGE_PAD * 2;
+  const viewBoxHeight = height + EDGE_PAD * 2;
+  const readout = readoutTarget && (
+    <div
+      style={{
+        position: 'absolute',
+        left: `${((readoutAnchor(readoutTarget).x + EDGE_PAD) / viewBoxWidth) * 100}%`,
+        top: `${((readoutAnchor(readoutTarget).y + EDGE_PAD) / viewBoxHeight) * 100}%`,
+        transform: 'translate(-50%, -140%)',
+        padding: '3rem 6rem',
+        borderRadius: '4rem',
+        backgroundColor: 'rgba(10, 10, 14, 0.85)',
+        color: WHITE,
+        fontSize: '11rem',
+        whiteSpace: 'nowrap',
+        pointerEvents: 'none',
+      }}
+    >
+      {readoutLabel(readoutTarget)}
+    </div>
+  );
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+      <svg
+        ref={graphRef}
+        width="100%"
+        height="100%"
+        viewBox={`${-EDGE_PAD} ${-EDGE_PAD} ${viewBoxWidth} ${viewBoxHeight}`}
+        preserveAspectRatio="none"
+        style={{ display: 'block' }}
+      >
+        <defs>
+          <linearGradient
+            id={gradientId}
+            gradientUnits="userSpaceOnUse"
+            x1="0"
+            y1={height}
+            x2="0"
+            y2="0"
+          >
+            <stop offset="0%" stopColor={BRAND_YELLOW} />
+            <stop offset="100%" stopColor={BRAND_RED} />
+          </linearGradient>
+        </defs>
+        <line
+          x1={0}
+          y1={height / 2}
+          x2={width}
+          y2={height / 2}
+          stroke="rgba(235, 235, 245, 0.18)"
+          strokeWidth={1}
+        />
+        {/* Background time grid: fainter than EQ's own grid (0.05 vs 0.07) -
+            this one has to stay out of the waveform/curve's way, not read as
+            a peer axis. */}
+        {gridLinesX.map((x, i) => (
+          <line
+            key={i}
+            x1={x}
+            y1={0}
+            x2={x}
+            y2={height}
+            stroke="rgba(235, 235, 245, 0.05)"
+            strokeWidth={1}
+          />
+        ))}
+        {/* Under-curve fill (Space Designer style): the area between the
+            envelope curve and the graph floor below it (where the waveform
+            lives), not a flat rectangular wash - so it follows the curve's
+            actual shape (thin near a deep cut, filling most of the height
+            near Init/Peak where little is attenuated). Plain white at very
+            low opacity, not a new hue - keeps this passive, informational
+            distinction out of the way of the waveform's own yellow->red
+            gradient and the white curve/points drawn on top of it. Rendered
+            before the waveform so that stays fully crisp. */}
+        {fillPath && <path d={fillPath} fill="#ffffff" fillOpacity={0.06} />}
+        {waveformPath && (
+          <path
+            d={waveformPath}
+            fill={`url(#${gradientId})`}
+            fillOpacity={0.3}
+            stroke={`url(#${gradientId})`}
+            strokeWidth={1}
+            strokeOpacity={0.9}
+          />
+        )}
+        {cutFraction < 1 && (
+          <g>
+            <rect
+              x={cutX}
+              y={0}
+              width={width - cutX}
+              height={height}
+              fill="rgba(10, 10, 14, 0.55)"
+            />
+            <line
+              x1={cutX}
+              y1={0}
+              x2={cutX}
+              y2={height}
+              stroke={MUTED}
+              strokeWidth={1.5}
+              strokeDasharray="3 2"
+            />
+          </g>
+        )}
+        {segments && (
+          <>
+            {segmentHitPath('attack', segments.attackPath)}
+            {segmentHitPath('decay', segments.decayPath)}
+            <path
+              d={segments.attackPath}
+              fill="none"
+              stroke={WHITE}
+              strokeWidth={1.5}
+              strokeOpacity={0.85}
+            />
+            <path
+              d={segments.decayPath}
+              fill="none"
+              stroke={WHITE}
+              strokeWidth={1.5}
+              strokeOpacity={0.85}
+            />
+          </>
+        )}
+        {lengthLabel && (
+          <g>
+            <rect
+              x={width - labelMargin - labelWidth}
+              y={height - labelMargin - labelHeight}
+              width={labelWidth}
+              height={labelHeight}
+              rx={labelHeight / 3}
+              fill="rgba(10, 10, 14, 0.55)"
+            />
+            <text
+              x={width - labelMargin - labelWidth / 2}
+              y={height - labelMargin - labelHeight / 2}
+              fontSize={labelFontSize}
+              fill={MUTED}
+              textAnchor="middle"
+              dominantBaseline="central"
+            >
+              {lengthLabel}
+            </text>
+          </g>
+        )}
+        {/* Predelay indicator: a left-edge line mirroring the cut line's own
+            treatment (same stroke/dash), shown only when there's actually a
+            predelay to signal - zero visual cost at the default (0) case.
+            Display-only: the Delay knob in the Input rail is still what
+            changes this. Rendered after the fill/waveform/curve so it stays
+            visible on top of them at x=0. */}
+        {predelay > 0 && (
+          <line
+            x1={0}
+            y1={0}
+            x2={0}
+            y2={height}
+            stroke={MUTED}
+            strokeWidth={1.5}
+            strokeDasharray="3 2"
+          />
+        )}
+
+        {/* Points render last (on top) so they win hit-testing within their
+          own radius over anything drawn beneath them. */}
+        {ring('init', 0, initY)}
+        {hitCircle('init', 0, initY)}
+        {dot(0, initY)}
+        {ring('peak', peakX, 0)}
+        {hitCircle('peak', peakX, 0)}
+        {dot(peakX, 0)}
+        {ring('end', cutX, endY)}
+        {hitCircle('end', cutX, endY)}
+        {dot(cutX, endY)}
+      </svg>
+      {readout}
+    </div>
+  );
+};

--- a/ui/src/components/IrEnvelopeGraph.tsx
+++ b/ui/src/components/IrEnvelopeGraph.tsx
@@ -442,6 +442,7 @@ export const IrEnvelopeGraph: React.FC<{
       onPointerMove={handlePointerMove(target)}
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
+      onDoubleClick={() => resetTarget(target)}
     />
   );
 
@@ -452,13 +453,23 @@ export const IrEnvelopeGraph: React.FC<{
   // regardless of the card's actual rendered size.
   const viewBoxWidth = width + EDGE_PAD * 2;
   const viewBoxHeight = height + EDGE_PAD * 2;
-  const readout = readoutTarget && (
+  // Edge avoidance: the default placement offsets the chip above its anchor
+  // (translateY -140%, i.e. the box's own height plus a small gap) - fine
+  // everywhere except near the top of the graph (dragging Init toward unity,
+  // Peak is always here), where that pushes the chip above the card's own
+  // clipped boundary (same class of edge-clipping the points themselves hit
+  // before EDGE_PAD, but this is a plain HTML overlay, not SVG, so the fix
+  // is a flip rather than a viewBox pad). Mirrors typical tooltip
+  // edge-avoidance: flip to sit below instead when there's no room above.
+  const readoutAnchorPoint = readoutTarget ? readoutAnchor(readoutTarget) : null;
+  const readoutNearTop = readoutAnchorPoint !== null && readoutAnchorPoint.y < height * 0.2;
+  const readout = readoutTarget && readoutAnchorPoint && (
     <div
       style={{
         position: 'absolute',
-        left: `${((readoutAnchor(readoutTarget).x + EDGE_PAD) / viewBoxWidth) * 100}%`,
-        top: `${((readoutAnchor(readoutTarget).y + EDGE_PAD) / viewBoxHeight) * 100}%`,
-        transform: 'translate(-50%, -140%)',
+        left: `${((readoutAnchorPoint.x + EDGE_PAD) / viewBoxWidth) * 100}%`,
+        top: `${((readoutAnchorPoint.y + EDGE_PAD) / viewBoxHeight) * 100}%`,
+        transform: `translate(-50%, ${readoutNearTop ? '40%' : '-140%'})`,
         padding: '3rem 6rem',
         borderRadius: '4rem',
         backgroundColor: 'rgba(10, 10, 14, 0.85)',

--- a/ui/src/components/Plugin.tsx
+++ b/ui/src/components/Plugin.tsx
@@ -365,6 +365,7 @@ export const Plugin: React.FC = () => {
       refreshToneMetadata: actions.refreshToneMetadata,
       setBlockParam: actions.setBlockParam,
       setBlockSlimSize: actions.setBlockSlimSize,
+      setBlockIrDecay: actions.setBlockIrDecay,
       setBlockEqBand: actions.setBlockEqBand,
       setBlockEqEnabled: actions.setBlockEqEnabled,
       setBlockEqPre: actions.setBlockEqPre,

--- a/ui/src/components/WaveformDisplay.tsx
+++ b/ui/src/components/WaveformDisplay.tsx
@@ -1,0 +1,333 @@
+import React, { useMemo } from 'react';
+import { BRAND_YELLOW, BRAND_RED, MUTED, WHITE } from './theme';
+import { envelopeDbAt } from './decayEnvelope';
+
+/** Visual dB floor for the envelope overlay's Y-axis - matches
+    decayEnvelope.ts's SILENCE_DB exactly, so the plotted line never clips
+    before the real math does. (An earlier, shallower floor here (-48dB)
+    predated levels reaching true silence at -100dB and was clamping/
+    flattening most of any real envelope well before its actual endpoint -
+    a visualization bug, not a DSP one; the underlying dB math was already
+    smooth and monotonic at every curve/level combination.) */
+export const ENVELOPE_DB_FLOOR = -100;
+
+/** dB -> Y (0 at unity/top, `height` at ENVELOPE_DB_FLOOR/bottom), and its
+    inverse. Shared with IrEnvelopeGraph.tsx so a dragged point's pixel
+    position round-trips through the same dB domain the curve itself is
+    plotted in, rather than a separate linear shortcut that could drift from
+    this if the floor ever changed. */
+export const dbToY = (db: number, height: number): number => {
+  const t = Math.max(0, Math.min(1, (0 - db) / (0 - ENVELOPE_DB_FLOOR)));
+  return t * height;
+};
+export const yToDb = (y: number, height: number): number => {
+  const t = Math.max(0, Math.min(1, y / height));
+  return t * ENVELOPE_DB_FLOOR; // t=0 -> 0dB, t=1 -> ENVELOPE_DB_FLOOR
+};
+
+/** "480ms" under a second, "2.67s" at or above. Single source of truth for
+    this formatting - also used by the Length knob's readout (knobScale.ts's
+    lengthMsScale), so the chip and the knob always agree. */
+export function formatContentLength(ms: number): string | null {
+  if (!Number.isFinite(ms) || ms <= 0) return null;
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(2)}s`;
+}
+
+/** Builds the filled top/bottom polygon path for a min/max waveform strip.
+    Shared with IrEnvelopeGraph.tsx so the interactive editor draws the exact
+    same backdrop shape as this display-only view. */
+export function buildWaveformPath(
+  mins: number[],
+  maxs: number[],
+  width: number,
+  height: number
+): string {
+  const n = Math.min(mins.length, maxs.length);
+  if (n < 2) return '';
+  const clamp = (v: number) => Math.max(-1, Math.min(1, v));
+  const midY = height / 2;
+  const xStep = width / (n - 1);
+  const top = maxs.map(
+    (v, i) => `${(i * xStep).toFixed(1)} ${(midY - clamp(v) * midY).toFixed(1)}`
+  );
+  const bottom = mins
+    .map((v, i) => `${(i * xStep).toFixed(1)} ${(midY - clamp(v) * midY).toFixed(1)}`)
+    .reverse();
+  return `M${top.join(' L')} L${bottom.join(' L')} Z`;
+}
+
+export interface EnvelopeDecayParams {
+  initLevel: number;
+  attackCurve: number;
+  attackFraction: number;
+  decayLevel: number;
+  decayCurve: number;
+}
+
+export interface DecaySegmentPaths {
+  /** Init -> Peak. */
+  attackPath: string;
+  /** Peak -> End. */
+  decayPath: string;
+}
+
+interface CurvePoint {
+  x: number;
+  y: number;
+}
+
+/** Shared sampling for buildDecaySegments/buildDecayFillPath: the envelope's
+    Init->Peak and Peak->End segments, each as its own ordered point list
+    (both include the shared boundary point at Peak, so either concatenation
+    - path-per-segment or one continuous fill outline - lands exactly on the
+    same spot with no seam). Each segment is sampled (and biased) separately
+    rather than off one uniform 0..1 grid so the Attack/Decay boundary always
+    gets an exact point at its true x-position regardless of curve, and each
+    segment's steepest region (x^k's unbounded derivative at t=0 for
+    curve<0.5, its bounded-but-steepest point at t=1 for curve>=0.5) gets
+    extra sampling resolution. */
+function sampleDecayPoints(
+  decay: EnvelopeDecayParams,
+  cutX: number,
+  height: number
+): { attack: CurvePoint[]; decay: CurvePoint[] } {
+  const biasedT = (t: number, curveNormalized: number) =>
+    curveNormalized < 0.5 ? t * t : 1 - (1 - t) * (1 - t);
+  const stepsPerSegment = 16;
+  const boundary = Math.max(0, Math.min(1, decay.attackFraction));
+  const pointAt = (fraction: number): CurvePoint => {
+    const db = envelopeDbAt(
+      fraction,
+      decay.attackFraction,
+      decay.initLevel,
+      decay.attackCurve,
+      decay.decayLevel,
+      decay.decayCurve
+    );
+    return { x: fraction * cutX, y: dbToY(db, height) };
+  };
+  const attack: CurvePoint[] = [];
+  for (let i = 0; i <= stepsPerSegment; i++) {
+    attack.push(pointAt(biasedT(i / stepsPerSegment, decay.attackCurve) * boundary));
+  }
+  const decayPts: CurvePoint[] = [pointAt(boundary)];
+  for (let i = 1; i <= stepsPerSegment; i++) {
+    decayPts.push(
+      pointAt(boundary + biasedT(i / stepsPerSegment, decay.decayCurve) * (1 - boundary))
+    );
+  }
+  return { attack, decay: decayPts };
+}
+
+const pointsToPath = (points: CurvePoint[]): string =>
+  `M${points.map((p) => `${p.x.toFixed(1)} ${p.y.toFixed(1)}`).join(' L')}`;
+
+/** Samples the 2-segment envelope into two SVG (sub)paths, from x=0 to the
+    Attack/Decay boundary and from there to `cutX` - kept as two separate
+    strings (rather than one continuous path) so IrEnvelopeGraph.tsx can pair
+    each segment with its own curve-line drag hit-path. Concatenating both
+    strings reproduces the exact single-path rendering this used to build
+    directly (see `buildDecayPath` below) - they share the exact same
+    boundary point, so there's no visible seam. */
+export function buildDecaySegments(
+  decay: EnvelopeDecayParams,
+  cutX: number,
+  height: number
+): DecaySegmentPaths {
+  const { attack, decay: decayPts } = sampleDecayPoints(decay, cutX, height);
+  return {
+    attackPath: pointsToPath(attack),
+    decayPath: pointsToPath(decayPts),
+  };
+}
+
+/** Closed fill polygon for the "area under the curve" wash (IrEnvelopeGraph):
+    the envelope curve itself as the top/side edge, closed off with two
+    straight segments back along y=height (the graph's floor, where the
+    waveform/silence sits) to (cutX, height) and (0, height) - the classic
+    "area chart filled down to the baseline" technique, mirroring
+    buildWaveformPath's own top/bottom polygon but closed against a flat
+    floor instead of a second sampled curve. This fills the region the
+    envelope actually passes THROUGH (down to where the waveform lives), not
+    the headroom it's carved away above. */
+export function buildDecayFillPath(
+  decay: EnvelopeDecayParams,
+  cutX: number,
+  height: number
+): string {
+  const { attack, decay: decayPts } = sampleDecayPoints(decay, cutX, height);
+  const curvePoints = [...attack, ...decayPts.slice(1)]; // dedupe the shared boundary point
+  const last = curvePoints[curvePoints.length - 1];
+  return `${pointsToPath(curvePoints)} L${last.x.toFixed(1)} ${height} L0 ${height} Z`;
+}
+
+/** Samples the 2-segment envelope into one continuous SVG path, from x=0 to
+    `cutX`. Shared with IrEnvelopeGraph.tsx so the interactive editor's curve
+    is pixel-identical to this display-only rendering. */
+export function buildDecayPath(decay: EnvelopeDecayParams, cutX: number, height: number): string {
+  const { attackPath, decayPath } = buildDecaySegments(decay, cutX, height);
+  return `${attackPath} ${decayPath}`;
+}
+
+/**
+ * Static IR waveform for a block card. Mirrors the EQ graph's visual
+ * language (BlockEqView.tsx / SpectrumBackdrop.tsx): a faint center
+ * reference line under a gradient-filled curve, no separate grid. Takes
+ * independent width/height (rather than a single square boxSize) so it can
+ * render as a wide, short strip - the shape the IR block's compact layout
+ * uses, and the one the future drag-to-shape v2 surface will want more
+ * horizontal resolution for. Display-only for this POC: no drag/edit points.
+ */
+export const WaveformDisplay: React.FC<{
+  mins: number[];
+  maxs: number[];
+  width: number;
+  height: number;
+  /** Detected content length in ms (native, RMS-threshold based) - the same
+      window these mins/maxs are already trimmed to, so the label always
+      matches what's drawn. Omitted/non-finite hides the label. */
+  contentLengthMs?: number;
+  /** Length knob's current position, normalized 0..1 against this same
+      fixed window (1.0 = untrimmed, matching lengthMsScale's own mapping).
+      Drawn as a cut line + dimmed region live, entirely client-side - the
+      backdrop (mins/maxs) never moves or rescales while dragging; only this
+      overlay does. Omitted or >=1 hides it. */
+  cutFraction?: number;
+  /** Envelope knobs' current position (see BlockParams.initLevel/
+      attackCurve/decayLevel/decayCurve). Attack's peak is pinned at
+      unity/0dB (not a param). `attackFraction` is where the Attack/Decay
+      boundary sits within [0, cutFraction] (0..1 - the caller derives this
+      from the same Attack/Decay Length knobs that feed cutFraction). Drawn
+      as a static 2-segment line from x=0 to the cut point (the envelope
+      only lives within the truncated content), live and client-side like
+      cutFraction - v1 is a visualization only, not yet draggable (see
+      decayEnvelope.ts for the shared curve math). Omitted, or both levels
+      exactly 1.0 (flat/no-op, mirroring prepareIrShapeRebuild's own
+      envelopeIsFlat skip), hides it. */
+  decay?: {
+    initLevel: number;
+    attackCurve: number;
+    attackFraction: number;
+    decayLevel: number;
+    decayCurve: number;
+  };
+}> = ({ mins, maxs, width, height, contentLengthMs, cutFraction, decay }) => {
+  const path = useMemo(
+    () => buildWaveformPath(mins, maxs, width, height),
+    [mins, maxs, width, height]
+  );
+
+  if (!path) return null;
+
+  const hasCut = Number.isFinite(cutFraction) && (cutFraction as number) < 1;
+  const cutX = hasCut ? width * Math.max(0, cutFraction as number) : width;
+
+  // Envelope line: only within [0, cutX] (the truncated content the
+  // envelope actually shapes), only when every level isn't at its 1.0 no-op
+  // unity - mirrors prepareIrShapeRebuild's own envelopeIsFlat skip exactly.
+  // Y-axis is dB, not the waveform's linear amplitude - true exponential
+  // decay is linear-in-dB, and a linear-amplitude plot would misrepresent
+  // the actual curve shape. Unity (1.0/0dB) sits at the top edge now (not a
+  // center line - levels are attenuation-only, never above unity); the
+  // bottom edge is ENVELOPE_DB_FLOOR, a visual-only floor (see its own
+  // comment) since the levels' true floor (SILENCE_DB) is far deeper than
+  // is useful to actually plot.
+  // Sampled/biased separately per segment (rather than one uniform 0..1
+  // grid) so the Attack/Decay boundary always gets an exact point at its
+  // true x-position regardless of curve, and each segment's steepest region
+  // (x^k's unbounded derivative at t=0 for curve<0.5, its bounded-but-
+  // steepest point at t=1 for curve>=0.5) gets extra resolution - see
+  // buildDecayPath.
+  const hasDecay = !!decay && (decay.initLevel !== 1 || decay.decayLevel !== 1);
+  const decayPath = hasDecay && decay ? buildDecayPath(decay, cutX, height) : '';
+
+  const lengthLabel = formatContentLength(contentLengthMs ?? NaN);
+  const labelFontSize = Math.max(9, height * 0.16);
+  const labelPaddingX = labelFontSize * 0.55;
+  const labelPaddingY = labelFontSize * 0.3;
+  const labelMargin = labelFontSize * 0.5;
+  const labelWidth = lengthLabel ? lengthLabel.length * labelFontSize * 0.6 + labelPaddingX * 2 : 0;
+  const labelHeight = labelFontSize + labelPaddingY * 2;
+  const gradientId = 'ir-waveform-gradient';
+  return (
+    <svg
+      width="100%"
+      height="100%"
+      viewBox={`0 0 ${width} ${height}`}
+      preserveAspectRatio="none"
+      style={{ display: 'block' }}
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          gradientUnits="userSpaceOnUse"
+          x1="0"
+          y1={height}
+          x2="0"
+          y2="0"
+        >
+          <stop offset="0%" stopColor={BRAND_YELLOW} />
+          <stop offset="100%" stopColor={BRAND_RED} />
+        </linearGradient>
+      </defs>
+      {/* Center (zero-amplitude) reference line, under the waveform - same
+          treatment as the EQ graph's 0dB line. */}
+      <line
+        x1={0}
+        y1={height / 2}
+        x2={width}
+        y2={height / 2}
+        stroke="rgba(235, 235, 245, 0.18)"
+        strokeWidth={1}
+      />
+      <path
+        d={path}
+        fill={`url(#${gradientId})`}
+        fillOpacity={0.3}
+        stroke={`url(#${gradientId})`}
+        strokeWidth={1}
+        strokeOpacity={0.9}
+      />
+      {hasCut && (
+        <g>
+          {/* Everything past the cut: this is what Length would remove. */}
+          <rect x={cutX} y={0} width={width - cutX} height={height} fill="rgba(10, 10, 14, 0.55)" />
+          <line
+            x1={cutX}
+            y1={0}
+            x2={cutX}
+            y2={height}
+            stroke={MUTED}
+            strokeWidth={1.5}
+            strokeDasharray="3 2"
+          />
+        </g>
+      )}
+      {hasDecay && decayPath && (
+        <path d={decayPath} fill="none" stroke={WHITE} strokeWidth={1.5} strokeOpacity={0.85} />
+      )}
+      {lengthLabel && (
+        <g>
+          <rect
+            x={width - labelMargin - labelWidth}
+            y={height - labelMargin - labelHeight}
+            width={labelWidth}
+            height={labelHeight}
+            rx={labelHeight / 3}
+            fill="rgba(10, 10, 14, 0.55)"
+          />
+          <text
+            x={width - labelMargin - labelWidth / 2}
+            y={height - labelMargin - labelHeight / 2}
+            fontSize={labelFontSize}
+            fill={MUTED}
+            textAnchor="middle"
+            dominantBaseline="central"
+          >
+            {lengthLabel}
+          </text>
+        </g>
+      )}
+    </svg>
+  );
+};

--- a/ui/src/components/decayEnvelope.ts
+++ b/ui/src/components/decayEnvelope.ts
@@ -17,13 +17,24 @@ export const DECAY_CURVE_MAX = 6.0;
     snap-to-zero), not this constant's job. */
 export const SILENCE_DB = -100.0;
 
+/** Compresses sensitivity around curveNormalized=0.5 while leaving 0 and 1
+    exactly where they were - must match ProcessorModelLoader.cpp's
+    shapeCurveNormalized exactly (see its own comment for why: a straight
+    linear (c-0.5) made even a small drag off center swing the exponent
+    enough to make the curve sound almost like a step function well before
+    it looked like one on the coarsely-sampled graph). */
+function shapeCurveNormalized(c: number): number {
+  const d = c - 0.5;
+  return Math.sign(d) * Math.pow(Math.abs(2 * d), 3) * 0.5;
+}
+
 /** curveNormalized 0..1 -> the power-curve exponent k. 0.5 -> k=1 (linear
     in dB - constant-ratio/"exponential" decay, already natural-sounding);
     toward 0 shrinks below 1 (even steeper, more front-loaded: fast initial
     drop, long quiet tail); toward 1 grows past 1 (back-loaded: holds near
     the segment's start level, then drops right at the end). */
 export function decayCurveExponent(curveNormalized: number): number {
-  return Math.pow(DECAY_CURVE_MAX, 2 * (curveNormalized - 0.5));
+  return Math.pow(DECAY_CURVE_MAX, 2 * shapeCurveNormalized(curveNormalized));
 }
 
 /** Level (0..1, unipolar attenuation-only; 1.0 = unity/0dB, 0.0 = genuine

--- a/ui/src/components/decayEnvelope.ts
+++ b/ui/src/components/decayEnvelope.ts
@@ -1,0 +1,100 @@
+/**
+ * Client-side mirror of prepareIrShapeRebuild's 2-segment Attack/Decay
+ * envelope math (ProcessorModelLoader.cpp) - used only to draw the overlay
+ * line in WaveformDisplay, never to compute audio. Keep DECAY_CURVE_MAX,
+ * SILENCE_DB and the formula shape in sync with the native side by hand;
+ * there is no way to share the actual code across the C++/TS boundary, and a
+ * mismatch here only misdraws a line, it can't affect what's heard.
+ */
+
+/** Must match ProcessorModelLoader.cpp's kCurveMax exactly. */
+export const DECAY_CURVE_MAX = 6.0;
+
+/** Must match ProcessorModelLoader.cpp's kSilenceDb exactly - the reachable,
+    finite floor levelToDb's linear-in-dB mapping uses for 0 < normalized <=
+    1; true silence at the literal normalized=0 case is a separate, exact
+    discrete case (see levelToDb and prepareIrShapeRebuild's own
+    snap-to-zero), not this constant's job. */
+export const SILENCE_DB = -100.0;
+
+/** curveNormalized 0..1 -> the power-curve exponent k. 0.5 -> k=1 (linear
+    in dB - constant-ratio/"exponential" decay, already natural-sounding);
+    toward 0 shrinks below 1 (even steeper, more front-loaded: fast initial
+    drop, long quiet tail); toward 1 grows past 1 (back-loaded: holds near
+    the segment's start level, then drops right at the end). */
+export function decayCurveExponent(curveNormalized: number): number {
+  return Math.pow(DECAY_CURVE_MAX, 2 * (curveNormalized - 0.5));
+}
+
+/** Level (0..1, unipolar attenuation-only; 1.0 = unity/0dB, 0.0 = genuine
+    silence) -> dB. Linear-in-dB (SILENCE_DB at normalized=0, 0dB at
+    normalized=1) - matches every other gain knob in this codebase
+    (gainDbScale, gateDbScale, ...), so knob travel feels proportional
+    across the whole range. A true logarithmic (20*log10(n)) mapping was
+    tried first, treating the knob's own 0..1 as if it directly were linear
+    amplitude - but that compresses almost the entire dB range into the
+    last sliver of travel near normalized=0, making the knob feel like it
+    does nothing for most of its travel then cliff-dives to silent. Genuine
+    silence at the literal normalized=0 case is still exact - it's just a
+    separate, discrete case (mirroring prepareIrShapeRebuild's own
+    snap-to-zero), not something this formula's shape needs to produce. */
+export function levelToDb(normalized: number): number {
+  if (normalized <= 0) return SILENCE_DB;
+  return SILENCE_DB * (1 - normalized);
+}
+
+/** Inverse of `levelToDb`: dB -> level (0..1, clamped). Used by the envelope
+    graph (IrEnvelopeGraph.tsx) to turn a dragged point's on-screen dB
+    position back into a normalized level. */
+export function dbToLevel(db: number): number {
+  if (db <= SILENCE_DB) return 0;
+  if (db >= 0) return 1;
+  return 1 - db / SILENCE_DB;
+}
+
+/** dB at a point `fraction` (0..1) through one segment, warped by that
+    segment's own curve. The warp has to be applied in dB, not linear
+    amplitude: true exponential decay is linear-in-dB, and this is also the
+    domain WaveformDisplay's overlay plots on, so a Curve=0.5 (k=1) segment
+    is a genuine straight line there. */
+function segmentDbAt(
+  fraction: number,
+  fromDb: number,
+  toDb: number,
+  curveNormalized: number
+): number {
+  const k = decayCurveExponent(curveNormalized);
+  const clampedFraction = Math.max(0, Math.min(1, fraction));
+  return fromDb + (toDb - fromDb) * Math.pow(clampedFraction, k);
+}
+
+/** One point along the 2-segment envelope: `fraction` is 0..1 across the
+    *whole* truncated content (Attack followed by Decay), matching
+    WaveformDisplay's cutFraction-relative x-axis. `attackFraction` is where
+    the Attack/Decay boundary sits within that same 0..1 span (i.e.
+    attackLengthSamples / (attackLengthSamples + decayLengthSamples) -
+    WaveformDisplay computes this the same way ChainBlock.tsx derives
+    cutFraction, since both come from the same two length knobs). Attack's
+    peak is pinned at unity/0dB (not a param) - standard AD-envelope
+    semantics, mirroring prepareIrShapeRebuild's own hardcoded attackDb. */
+export function envelopeDbAt(
+  fraction: number,
+  attackFraction: number,
+  initLevelNormalized: number,
+  attackCurveNormalized: number,
+  decayLevelNormalized: number,
+  decayCurveNormalized: number
+): number {
+  const initDb = levelToDb(initLevelNormalized);
+  const attackDb = 0; // Attack's peak is pinned at unity/0dB
+  const decayDb = levelToDb(decayLevelNormalized);
+  const clampedFraction = Math.max(0, Math.min(1, fraction));
+  const clampedBoundary = Math.max(0, Math.min(1, attackFraction));
+  if (clampedFraction < clampedBoundary) {
+    const segFraction = clampedBoundary > 0 ? clampedFraction / clampedBoundary : 1;
+    return segmentDbAt(segFraction, initDb, attackDb, attackCurveNormalized);
+  }
+  const decaySpan = 1 - clampedBoundary;
+  const segFraction = decaySpan > 0 ? (clampedFraction - clampedBoundary) / decaySpan : 1;
+  return segmentDbAt(segFraction, attackDb, decayDb, decayCurveNormalized);
+}

--- a/ui/src/components/decayEnvelope.ts
+++ b/ui/src/components/decayEnvelope.ts
@@ -7,8 +7,11 @@
  * mismatch here only misdraws a line, it can't affect what's heard.
  */
 
-/** Must match ProcessorModelLoader.cpp's kCurveMax exactly. */
-export const DECAY_CURVE_MAX = 6.0;
+/** Must match ProcessorModelLoader.cpp's kCurveMax exactly (see its own
+    comment for why 4.0, not the original 6.0 - real IR material already
+    carries its own natural decay, and the envelope's dB drop adds to that
+    rather than replacing it). */
+export const DECAY_CURVE_MAX = 4.0;
 
 /** Must match ProcessorModelLoader.cpp's kSilenceDb exactly - the reachable,
     finite floor levelToDb's linear-in-dB mapping uses for 0 < normalized <=

--- a/ui/src/components/helpText.ts
+++ b/ui/src/components/helpText.ts
@@ -233,6 +233,7 @@ export const HELP = {
   blockOut: knobHelp('Out', 'block output gain, ±24 dB.'),
   blockOutIr: knobHelp('Out', 'block output gain, ±24 dB (IR pre-trimmed -18 dB).'),
   blockMix: knobHelp('Mix', 'dry/wet blend.'),
+  blockPredelay: knobHelp('Predelay', 'delay before the IR player starts, up to 1s.'),
   blockNormalize: 'Normalize: level this block\u2019s loudness. Off: raw capture level.',
   blockNormalizeOverridden:
     'Normalize: overridden \u2014 calibration hands this model\u2019s true output level to the next NAM block.',

--- a/ui/src/components/helpText.ts
+++ b/ui/src/components/helpText.ts
@@ -209,7 +209,8 @@ export const HELP = {
   copyBlock: 'Copy: copy this block (tone, model and all settings).',
   pasteBlock: 'Paste: add a copy of the copied block in this slot.',
   loadFileTile: 'Load File: pick a local .nam or IR .wav file to load here. No account needed.',
-  loadFolderTile: 'Load Folder: pick a folder of .nam or .wav files; loads as one multi-model block.',
+  loadFolderTile:
+    'Load Folder: pick a folder of .nam or .wav files; loads as one multi-model block.',
   blockPower: 'Power: bypass this block.',
   retryLoad: 'Retry: re-download this model.',
   swapTone: 'Swap: replace this tone, keeping its slot.',
@@ -233,7 +234,44 @@ export const HELP = {
   blockOut: knobHelp('Out', 'block output gain, ±24 dB.'),
   blockOutIr: knobHelp('Out', 'block output gain, ±24 dB (IR pre-trimmed -18 dB).'),
   blockMix: knobHelp('Mix', 'dry/wet blend.'),
-  blockPredelay: knobHelp('Predelay', 'delay before the IR player starts, up to 1s.'),
+  blockPredelay: knobHelp('Delay', 'delay before the IR player starts, up to 1s.'),
+  // IR shaping row: a 2-segment Attack/Decay envelope (Space Designer-style)
+  // over the truncated content. Decay Length sets the TOTAL trimmed length
+  // (the real "End" position); Attack Length is a position *within* that
+  // total marking the envelope's peak, not an independent length. Init
+  // Level is the level at the very start (not part of either segment);
+  // Attack ramps from there up to unity/0dB (its peak is pinned, not
+  // adjustable) at that position; Decay continues from the peak to the
+  // trimmed end. Levels are 0-100% attenuation-only (100% = unity, 0% =
+  // genuine silence).
+  blockInitLevel: knobHelp('Init', 'level at the very start of the IR. 100%: no change.'),
+  blockAttackLength: knobHelp(
+    'Attack',
+    'position of the envelope’s peak within the trimmed length.'
+  ),
+  blockAttackCurve: knobHelp(
+    'Attack Curve',
+    'Attack segment’s envelope shape, front-loaded to back-loaded. Center: linear.'
+  ),
+  blockDecayLength: knobHelp('Decay', 'trims the IR’s tail - the envelope’s total length.'),
+  blockDecayLevel: knobHelp('Decay Level', 'level at the IR’s trimmed end. 100%: no change.'),
+  blockDecayCurve: knobHelp(
+    'Decay Curve',
+    'Decay segment’s envelope shape, front-loaded to back-loaded. Center: linear.'
+  ),
+  // Envelope graph (IrEnvelopeGraph.tsx): the same six values as the chips
+  // above, shaped directly on the waveform instead of typed in.
+  envelopeInitPoint: `Init: drag to set level at the IR\u2019s start. ${shift(
+    'drag'
+  )}: fine \u00b7 ${alt('click')} / double-click: reset.`,
+  envelopePeakPoint: `Attack: drag to set the envelope\u2019s peak position. ${shift(
+    'drag'
+  )}: fine \u00b7 ${alt('click')} / double-click: reset.`,
+  envelopeEndPoint: `Decay: drag to set trim length + end level. ${shift(
+    'drag'
+  )}: fine \u00b7 ${alt('click')} / double-click: reset.`,
+  envelopeAttackCurve: `Attack Curve: drag the line to bow the rise. ${shift('drag')}: fine.`,
+  envelopeDecayCurve: `Decay Curve: drag the line to bow the fall. ${shift('drag')}: fine.`,
   blockNormalize: 'Normalize: level this block\u2019s loudness. Off: raw capture level.',
   blockNormalizeOverridden:
     'Normalize: overridden \u2014 calibration hands this model\u2019s true output level to the next NAM block.',

--- a/ui/src/components/knobScale.ts
+++ b/ui/src/components/knobScale.ts
@@ -1,3 +1,5 @@
+import { formatContentLength } from './WaveformDisplay';
+
 /**
  * Display scales for knobs. Every knob's value is normalized (0..1 range,
  * matching APVTS / chain params); a KnobScale maps that to real units for
@@ -60,6 +62,58 @@ export const gateDbScale = linearScale(-100, 0, 'dB', 0);
 /** Per-block IR predelay: normalized 0..1 -> 0-1000ms, applied before the
     wet signal reaches the convolver (see BlockPredelay.h). */
 export const predelayMsScale = linearScale(0, 1000, 'ms', 0);
+
+/** Per-block IR content length: normalized 0..1 against the block's own
+    detected content (BlockParams.length / irContentLengthMs), from a small
+    floor up to the full detected length - mirrors the floor/lerp
+    prepareIrShapeRebuild (ProcessorModelLoader.cpp) uses closely enough for
+    a live readout (exact sample rounding is native's job, not the knob's).
+    Parameterized per block (unlike this file's other scales, the max varies
+    with what's loaded), same shape as sidedMsScale/panScale. `format` reuses
+    WaveformDisplay's formatContentLength so the knob readout and the
+    waveform's own corner label always agree. */
+export const lengthMsScale = (contentLengthMs: number): KnobScale => {
+  const minMs = 5;
+  const maxMs = Math.max(minMs, contentLengthMs);
+  const toDisplay = (n: number) => minMs + n * (maxMs - minMs);
+  const fromDisplay = (d: number) => (maxMs > minMs ? (d - minMs) / (maxMs - minMs) : 0);
+  return {
+    toDisplay,
+    fromDisplay,
+    format: (n) => formatContentLength(toDisplay(n)) ?? '0ms',
+    editText: (n) => toDisplay(n).toFixed(0),
+  };
+};
+
+/** Per-block IR Decay/Attack envelope shape: normalized 0..1, 0.5 (default)
+    is a linear ramp, sweeping toward -1 (log: fast-then-level) below and +1
+    (exp: holds-then-drops) above. Purely a display convention, plain signed
+    number, no unit - the actual power-curve formula (see
+    decayEnvelope.ts's DECAY_CURVE_MAX, mirroring prepareIrShapeRebuild's
+    kCurveMax in ProcessorModelLoader.cpp) operates on the normalized value
+    directly, not on this -1..+1 number. Shared by both the Attack and Decay
+    segments' own Curve knob. */
+export const curveScale: KnobScale = linearScale(-1, 1, '', 2);
+
+/** Per-block IR Attack Length (the envelope's peak position): normalized
+    0..1 against Decay Length's current real-ms value (BlockParams.
+    attackLength is a fraction *of* the total Decay Length sets, not an
+    independent length - totalMs is computed by the caller since it depends
+    on the live Decay Length knob) - mirrors lengthMsScale's own floor/lerp
+    shape and reuses its formatContentLength readout, just against a dynamic
+    (not fixed) max that moves with Decay Length. */
+export const attackLengthMsScale = (totalMs: number): KnobScale => {
+  const minMs = 5;
+  const maxMs = Math.max(minMs, totalMs);
+  const toDisplay = (n: number) => minMs + n * (maxMs - minMs);
+  const fromDisplay = (d: number) => (maxMs > minMs ? (d - minMs) / (maxMs - minMs) : 0);
+  return {
+    toDisplay,
+    fromDisplay,
+    format: (n) => formatContentLength(toDisplay(n)) ?? '0ms',
+    editText: (n) => toDisplay(n).toFixed(0),
+  };
+};
 
 /** Faceplate tone stack knobs: 0..10, 5 = flat. */
 export const toneScale = linearScale(0, 10, '', 1);

--- a/ui/src/components/knobScale.ts
+++ b/ui/src/components/knobScale.ts
@@ -57,6 +57,10 @@ export const balanceDbScale = linearScale(-12, 12, 'dB', 1);
 /** Gate threshold: normalized spans -100..0 dB. */
 export const gateDbScale = linearScale(-100, 0, 'dB', 0);
 
+/** Per-block IR predelay: normalized 0..1 -> 0-1000ms, applied before the
+    wet signal reaches the convolver (see BlockPredelay.h). */
+export const predelayMsScale = linearScale(0, 1000, 'ms', 0);
+
 /** Faceplate tone stack knobs: 0..10, 5 = flat. */
 export const toneScale = linearScale(0, 10, '', 1);
 

--- a/ui/src/hooks/useChainActions.ts
+++ b/ui/src/hooks/useChainActions.ts
@@ -86,6 +86,22 @@ export interface ChainActions {
   /** The block's NAM A2 size (0 = lite, 1 = full); retiers the loaded
       engine natively. Backs the header LITE/FULL toggle. */
   setBlockSlimSize: (blockId: string, slimSize: number) => void;
+  /** IR envelope: a 2-segment Attack/Decay shape (see BlockParams.initLevel/
+      attackLength/attackCurve/decayLength/decayLevel/decayCurve). Not
+      fire-and-forget-safe at knob-drag rates - rebuilds the convolver
+      off-thread, so callers should debounce (see ChainBlock.tsx's shaping
+      row). All six values arrive together (like setBlockEqBand's
+      whole-band updates) so a drag on one can't clobber another's in-flight
+      value. */
+  setBlockIrDecay: (
+    blockId: string,
+    initLevelNormalized: number,
+    attackLengthNormalized: number,
+    attackCurveNormalized: number,
+    decayLengthNormalized: number,
+    decayLevelNormalized: number,
+    decayCurveNormalized: number
+  ) => void;
   /** Fire-and-forget whole-band EQ setter (see useChainState). */
   setBlockEqBand: (blockId: string, bandIndex: number, band: EqBand) => void;
   /** EQ power/bypass: band settings persist, processing is skipped. */

--- a/ui/src/hooks/useChainState.ts
+++ b/ui/src/hooks/useChainState.ts
@@ -73,6 +73,7 @@ export function useChainState() {
       setStereoMode: backend.getPluginFunction('setStereoMode'),
       setInputMode: backend.getPluginFunction('setInputMode'),
       setBlockSlimSize: backend.getPluginFunction('setBlockSlimSize'),
+      setBlockIrDecay: backend.getPluginFunction('setBlockIrDecay'),
       setNamSlimSizeDefault: backend.getPluginFunction('setNamSlimSizeDefault'),
       setMultiCore: backend.getPluginFunction('setMultiCore'),
       setActiveEditChain: backend.getPluginFunction('setActiveEditChain'),
@@ -203,6 +204,34 @@ export function useChainState() {
           part of the chain state, so it lands in presets and undo. */
       setBlockSlimSize: (blockId: string, slimSize: number) =>
         run<boolean>('setBlockSlimSize', () => native.setBlockSlimSize(blockId, slimSize)),
+      /** IR envelope: a 2-segment Attack/Decay shape (see BlockParams.
+          initLevel/attackLength/attackCurve/decayLength/decayLevel/
+          decayCurve). Rebuilds the convolver off-thread under a wet-mute
+          fade; the caller debounces drag-rate calls (this isn't
+          fire-and-forget-safe at knob-drag rates the way setBlockParam is -
+          each call queues a real engine rebuild). All six values travel
+          together so a drag on one can't clobber another's in-flight
+          value. */
+      setBlockIrDecay: (
+        blockId: string,
+        initLevelNormalized: number,
+        attackLengthNormalized: number,
+        attackCurveNormalized: number,
+        decayLengthNormalized: number,
+        decayLevelNormalized: number,
+        decayCurveNormalized: number
+      ) =>
+        run<boolean>('setBlockIrDecay', () =>
+          native.setBlockIrDecay(
+            blockId,
+            initLevelNormalized,
+            attackLengthNormalized,
+            attackCurveNormalized,
+            decayLengthNormalized,
+            decayLevelNormalized,
+            decayCurveNormalized
+          )
+        ),
       /** Default NAM A2 size for newly added blocks (machine-wide; existing
           blocks keep their own size). Persists on disk. */
       setNamSlimSizeDefault: (slimSize: number) =>

--- a/ui/src/hooks/useIrWaveform.ts
+++ b/ui/src/hooks/useIrWaveform.ts
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useNativeFunction } from './useFunction';
+
+export interface IrWaveform {
+  mins: number[];
+  maxs: number[];
+}
+
+/**
+ * Static per-column min/max peaks for an IR block's waveform display.
+ * Fetched once per loaded model (not a poll like useBlockSpectrum) - the
+ * data is static per load. Refetches whenever `activeModelId` changes, not
+ * just on mount/blockId change: a model switch via the dropdown or the
+ * ModelSelect prev/next chevrons (ChainBlock.tsx's handleModelSelect ->
+ * switchModel) keeps the same blockId and, per ToneBlock.loaded's own
+ * contract, `loaded` stays true the whole time (the previous model keeps
+ * playing until the new one is spliced in) - so without activeModelId in
+ * the dependency list this would only ever refresh on remount. Clears
+ * while `loaded` is false (mid-swap/reload) so a stale waveform never
+ * lingers under a different tone.
+ *
+ * Also refetches on `modelLoading` transitions, and this part is load-
+ * bearing, not belt-and-suspenders: `switchModel` (ProcessorChain.cpp) sets
+ * `activeModelId` and `modelLoading=true` *synchronously*, before the new
+ * model's file has even been read - `irWaveformPeaks` isn't replaced with
+ * the new model's data until the background job finishes and reaches
+ * `applyPreparedModelToChainBlock`, which is also where `modelLoading`
+ * flips back to `false` (same atomic step, same lock). So a fetch triggered
+ * by `activeModelId` alone races the actual prepare work: if it resolves
+ * before that background job finishes (routine for anything beyond a
+ * trivial file), `getIrWaveform` still returns the *previous* model's
+ * peaks, mislabeled as the new one - and since neither `activeModelId` nor
+ * `loaded` change again afterward, nothing was left to trigger a
+ * correcting refetch once the real data actually landed. Depending on
+ * `modelLoading`'s true->false edge closes that gap: by the time it flips,
+ * `irWaveformPeaks` is guaranteed current. The existing `alive` guard below
+ * already makes any number of overlapping fetches resolve safely regardless
+ * of order, so this can't reintroduce a race of its own.
+ */
+export function useIrWaveform(
+  blockId: string,
+  loaded: boolean,
+  activeModelId: number,
+  modelLoading: boolean
+): IrWaveform | null {
+  const getIrWaveform = useNativeFunction<IrWaveform>('getIrWaveform');
+  const [waveform, setWaveform] = useState<IrWaveform | null>(null);
+
+  useEffect(() => {
+    if (!loaded) {
+      setWaveform(null);
+      return;
+    }
+    let alive = true;
+    getIrWaveform(blockId).then((res) => {
+      if (alive && res && Array.isArray(res.mins) && Array.isArray(res.maxs)) {
+        setWaveform(res);
+      }
+    });
+    return () => {
+      alive = false;
+    };
+  }, [blockId, loaded, activeModelId, modelLoading, getIrWaveform]);
+
+  return waveform;
+}

--- a/ui/src/types/chain.ts
+++ b/ui/src/types/chain.ts
@@ -103,6 +103,9 @@ export interface BlockParams {
   outputGain: number;
   /** Dry/wet: 0 = dry, 1 = wet. */
   mix: number;
+  /** Normalized 0..1 -> 0-1000ms, delay before the wet signal enters the
+      IR's convolver. IR blocks only; inert for NAM blocks. */
+  predelay: number;
   /** Per-block 6-band EQ. Flat = skipped entirely on the audio thread. */
   eq: BlockEqParams;
 }
@@ -297,7 +300,13 @@ export function isUnchanged(res: ChainStateResponse): res is ChainStateUnchanged
 }
 
 /** Param names accepted by the native `setBlockParam` function. */
-export type BlockParamName = 'enabled' | 'normalize' | 'inputGain' | 'outputGain' | 'mix';
+export type BlockParamName =
+  | 'enabled'
+  | 'normalize'
+  | 'inputGain'
+  | 'outputGain'
+  | 'mix'
+  | 'predelay';
 
 /** Payload of the native `getMeterLevels` function (all values dB, -60 floor).
     Main meters ship as [L, R] pairs; mono sources report L == R. */

--- a/ui/src/types/chain.ts
+++ b/ui/src/types/chain.ts
@@ -106,6 +106,44 @@ export interface BlockParams {
   /** Normalized 0..1 -> 0-1000ms, delay before the wet signal enters the
       IR's convolver. IR blocks only; inert for NAM blocks. */
   predelay: number;
+  /** IR envelope: a 2-segment Attack/Decay shape (Space Designer-style) over
+      the block's own detected content (irContentLengthMs, frozen at load).
+      IR blocks only; inert for NAM blocks. Set via `setBlockIrDecay`, not
+      `setBlockParam`: unlike this list's other continuous params (real-time
+      smoothers), it rebuilds the convolver engine off-thread, and all six
+      values travel together in one call so a drag on one can't clobber
+      another's in-flight value.
+
+      `decayLength` is the TOTAL truncated length - the real "End" position,
+      a fraction of the full detected content, matching the old standalone
+      Length knob's own convention. `attackLength` is NOT an independent
+      length - it's a fraction *of that total*, marking where the envelope's
+      peak (the Attack/Decay boundary) sits within it, naturally bounded to
+      [0, the total] by construction: dragging Attack Length alone can never
+      change the total window length, only Decay Length does that.
+
+      `initLevel` is the level at sample 0 (the origin, not part of either
+      segment). The Attack segment runs from there up to unity/0dB - pinned,
+      not adjustable: standard AD-envelope semantics (Attack always reaches
+      full level; only Decay's target level is adjustable) - at
+      `attackLength`'s position; the Decay segment continues from that peak
+      to the truncated content's end (`decayLevel`). Both adjustable levels
+      are normalized 0..1, unipolar attenuation-only (via percentScale: 1.0
+      = unity/0dB, 0.0 = genuine silence - see decayEnvelope.ts's levelToDb,
+      mirroring prepareIrShapeRebuild's own native formula). Defaults
+      (attackLength 0.0, decayLength 1.0, every level 1.0) are a genuine
+      no-op: no attack ramp, decay spans the full content, flat/unity
+      envelope. */
+  initLevel: number;
+  attackLength: number;
+  /** Continuous per-segment envelope shape, normalized 0..1: 0.5 (default)
+      is a linear-in-dB ramp, sweeping toward more front-loaded below and
+      more back-loaded above - see knobScale.ts's curveScale and
+      decayEnvelope.ts's shared curve formula. */
+  attackCurve: number;
+  decayLength: number;
+  decayLevel: number;
+  decayCurve: number;
   /** Per-block 6-band EQ. Flat = skipped entirely on the audio thread. */
   eq: BlockEqParams;
 }
@@ -186,6 +224,10 @@ export interface ToneBlock {
       once the model loads. Drives the Mix knob's default (long = 50% wet)
       and the Out knob help (long IRs carry no -18 dB pad). */
   irLong: boolean;
+  /** Detected IR content length in ms (native, RMS-threshold based): where
+      the waveform display's auto-fit trims to. 0 for NAM blocks and IR
+      blocks not yet loaded. */
+  irContentLengthMs: number;
   /** NAM calibration metadata (dBu) off the loaded model; absent when the
       model carries none (or nothing is loaded yet). `inputLevelDbu` feeds
       input calibration; `outputLevelDbu` feeds the mid-chain calibrated


### PR DESCRIPTION
## Summary

Adds shaping controls for IR blocks: a Predelay knob, a 2-segment Attack/Decay
envelope over the IR's detected content length (Space Designer-style), and a
fully interactive graph to shape it by ear, backed by precision-entry chips
for landing exact values.

<img width="1552" height="879" alt="Screenshot 2026-09-10 at 12 55 03" src="https://github.com/user-attachments/assets/82d1db53-6611-464f-b6ca-c8be95f6e48c" />

- **Predelay**: up to 1s of silence before the wet signal enters the IR's
  convolver (real-time DSP stage, own knob in the Input rail).
- **Content length + envelope**: native detection of an IR's real extent
  (RMS-threshold based, independent of the file's raw duration), plus a
  2-segment Attack/Decay envelope over it - Init Level ramps up to unity at a
  peak position (Attack Length, a fraction of the trimmed total), then Decay
  continues from that peak to the trimmed end (Decay Level). Both segments
  have their own Curve shape parameter.
- **Real waveform visualization**: per-column min/max peaks rendered from
  the IR's actual audio, auto-fit to the detected content length rather
  than the file's raw duration - a 20ms cab capture with a long silent tail
  displays at a legible scale instead of being squeezed into a few pixels.
  The envelope graph and its interactive points/curves render directly on
  top of this.
- **Drag-on-graph editor**: three draggable points (Init/Peak/End) plus
  draggable curve segments directly on the waveform, mirroring the EQ
  editor's own dot-dragging conventions (hover rings, Shift-drag fine mode,
  Alt-click/double-click reset, a floating value readout during drag). An
  under-curve fill, a faint background time grid, and a left-edge predelay
  indicator round out the visualization - all within the same fixed-window
  coordinate system the original Length knob used.
- **Precision chips**: Init/A Len/A Crv/D Len/D Lvl/D Crv as click-to-type
  chips (shares its pattern with the EQ's own Freq/Gain/Q chips, extracted
  into a common `EditableChip`).

### A DSP tuning note worth flagging in review

The Curve parameter's normalized-to-exponent mapping got two passes after
by-ear testing surfaced a real oversensitivity: a drag of about 1/5 of the
graph's height was enough to push the effective exponent to a point where
~91% of a segment's entire dB change lands in its last 30% - audibly an
abrupt "choke" nothing on the graph visually suggested. Fixed by (1) cubing
the normalized input before exponentiating, which roughly doubles the drag
distance needed to reach a given curve near center while leaving both
extremes unchanged, and (2) lowering the ceiling itself (`kCurveMax`
6.0 -> 4.0), since real reverb/room IRs already carry their own natural
decay and the envelope's dB drop *adds* to that rather than replacing it -
even the old ceiling's *intentional* full-throw extreme read as a hard gate
once stacked on real material. Both changes are native/TS pairs kept in
sync by hand (`ProcessorModelLoader.cpp` / `decayEnvelope.ts`), and existing
curve-shape tests are unaffected since they compare against the (unchanged)
extremes.

## Test plan

- [x] `npm run lint` / `npm run build` (UI) - clean
- [x] `./script/test-dsp.sh` - **150/150 tests pass**, including new
      `IrContentLengthTest` and `IrDecayTest` coverage (truncation, dry-path
      isolation, tail attenuation, curve shaping, state-restore round trip)
- [x] Full plugin build (Standalone/AU/VST3/AAX/CLAP/LV2) - clean
- [x] Demo video: https://youtu.be/fIMWWxBkLzY

🤖 Generated with [Claude Code](https://claude.com/claude-code)