### PR TITLE
Open detail view for a block just added or swapped in

### DIFF
--- a/ui/src/hooks/useToneLoadFlow.ts
+++ b/ui/src/hooks/useToneLoadFlow.ts
@@ -1,7 +1,15 @@
 import { useCallback } from 'react';
 import type { useChainState } from './useChainState';
+import { DETAIL_BLOCK_STORAGE_KEY } from '../components/ChainView';
 import type { ChainSide } from '../types/chain';
 import type { Model, Tone } from '../types/tone';
+
+/** Land on the new/swapped block's expanded detail view as soon as it lands
+    in the chain, matching what tapping an existing tile does (issue #114).
+    Flip to false to fall back to just scrolling it into view in the gallery
+    instead — the sessionStorage handoff below stays the same either way, so
+    that's a one-line change, not a re-implementation. */
+const OPEN_DETAIL_ON_BLOCK_ADD = true;
 
 type ChainStateActions = ReturnType<typeof useChainState>['actions'];
 
@@ -102,16 +110,33 @@ export function useToneLoadFlow({
       sessionStorage.removeItem(INSERT_TARGET_STORAGE_KEY);
 
       const toneJson = JSON.stringify(tone);
-      setShowToneBrowser(false);
 
+      // Closing the browser unmounts it and mounts a fresh ChainView (see
+      // Plugin's showToneBrowser ternary), whose detail-view state reads
+      // DETAIL_BLOCK_STORAGE_KEY once, at that mount. So the browser can only
+      // close *after* we know which block to hand it — closing first and
+      // writing the key once the native call resolves would land one render
+      // too late (issue #114).
       if (swapBlockId) {
         const swapped = await actions.swapTone(swapBlockId, toneJson);
-        if (swapped) return;
+        if (swapped) {
+          if (OPEN_DETAIL_ON_BLOCK_ADD) {
+            sessionStorage.setItem(DETAIL_BLOCK_STORAGE_KEY, swapBlockId);
+          }
+          setShowToneBrowser(false);
+          return;
+        }
         console.warn('Swap target no longer exists; adding tone as a new block');
       }
 
       const blockId = await actions.loadTone(toneJson, insertBlockId ?? undefined);
-      if (!blockId) console.error('Failed to load tone');
+      if (!blockId) {
+        console.error('Failed to load tone');
+        setShowToneBrowser(false);
+        return;
+      }
+      if (OPEN_DETAIL_ON_BLOCK_ADD) sessionStorage.setItem(DETAIL_BLOCK_STORAGE_KEY, blockId);
+      setShowToneBrowser(false);
     },
     [actions, setShowToneBrowser]
   );


### PR DESCRIPTION
## Summary

- Adding/swapping a tone routes through the tone browser (`Plugin`'s
  `showToneBrowser` ternary), which unmounts `ChainView` entirely while
  open and mounts a fresh instance on close — so the new block's id
  never had anywhere to land, and the gallery came back scrolled to the
  far left instead of showing the block you just added.
- Persist the resolved block id via `ChainView`'s existing
  `DETAIL_BLOCK_STORAGE_KEY` (the same mechanism already used to survive
  the OAuth Select redirect) so the freshly-mounted `ChainView` opens
  straight into that block's detail view, matching what tapping an
  existing tile already does. Gated behind `OPEN_DETAIL_ON_BLOCK_ADD` so
  falling back to just centering the tile in the gallery instead is a
  one-line change later, not a re-implementation.
- Closing the browser (`setShowToneBrowser(false)`) now happens after
  the native `swapTone`/`loadTone` call resolves rather than before it:
  closing first would mount the fresh `ChainView` before the block id —
  and thus the sessionStorage write — existed, landing one render too
  late.

Fixes #114

## Test plan

- [x] `./script/test-dsp.sh` — 150/150 tests pass
- [x] `tsc -b` / `eslint` clean on the changed file
- [x] Full plugin build (Release, Standalone) succeeds
- [x] Manually verified in a freshly built Standalone: adding a new
      block opens straight into its detail view instead of leaving the
      gallery scrolled to the far left

🤖 Generated with [Claude Code](https://claude.com/claude-code)