### PR TITLE
Prev/Next navigation in expanded block view

### DIFF
--- a/ui/src/components/ChainBlock.tsx
+++ b/ui/src/components/ChainBlock.tsx
@@ -3,6 +3,8 @@ import {
   ArrowLeft,
   ArrowLeftRight,
   Bookmark,
+  ChevronLeft,
+  ChevronRight,
   Download,
   Equal,
   FolderClosed,
@@ -207,6 +209,12 @@ interface ChainBlockProps {
   namSlimSizeDefault: number;
   /** Return to the chain gallery (← BLOCK sits above the bordered card). */
   onBack: () => void;
+  /** Step to the previous/next block in this same lane (issue #83), skipping
+      insert slots; false/no-op at the lane's ends (no wraparound). */
+  hasPrev: boolean;
+  onPrev: () => void;
+  hasNext: boolean;
+  onNext: () => void;
   /** Info view fills the center column to the faceplate (Select Tone pattern). */
   onFillToFaceplate?: (fill: boolean) => void;
 }
@@ -220,6 +228,10 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
   sampleRate,
   namSlimSizeDefault,
   onBack,
+  hasPrev,
+  onPrev,
+  hasNext,
+  onNext,
   onFillToFaceplate,
 }) => {
   const { blockId, tone, params } = block;
@@ -509,6 +521,32 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
     }
   };
 
+  // Left/Right steps to the adjacent block (issue #83), ignored while typing
+  // or with a native <select>/editable element focused so it doesn't fight
+  // normal text/option navigation. Scoped to this component's own mount
+  // lifetime, so it's only live while the detail view is actually open.
+  // isSwitchingModel also guards it: switchModel has no cancel handle, so a
+  // step mid-switch is just ignored rather than left to race.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (
+        e.target instanceof Element &&
+        e.target.closest('input, textarea, select, [contenteditable]')
+      ) {
+        return;
+      }
+      if (e.key === 'ArrowLeft' && hasPrev && !isSwitchingModel) {
+        e.preventDefault();
+        onPrev();
+      } else if (e.key === 'ArrowRight' && hasNext && !isSwitchingModel) {
+        e.preventDefault();
+        onNext();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [hasPrev, hasNext, isSwitchingModel, onPrev, onNext]);
+
   // A model download/prepare is in flight (switch, swap or first load). The
   // previous model keeps playing during a switch (`loaded` stays true), so
   // loading affordances key off `modelLoading`, not `loaded`.
@@ -570,39 +608,64 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
           padding: showInfo ? '24rem 0' : 0,
         }}
       >
-        {/* ← BLOCK sits above the bordered card (Figma: 16px mono, gap 16). */}
-        <button
-          type="button"
-          onClick={onBack}
-          {...helpProps(HELP.backToChain)}
+        {/* ← BLOCK sits above the bordered card (Figma: 16px mono, gap 16);
+            Prev/Next (issue #83) share the row, right-aligned. */}
+        <div
           style={{
-            alignSelf: 'flex-start',
             display: 'flex',
             alignItems: 'center',
-            gap: '16rem',
+            justifyContent: 'space-between',
             marginBottom: '16rem',
             flexShrink: 0,
-            background: 'transparent',
-            border: 'none',
-            outline: 'none',
-            padding: 0,
-            cursor: 'pointer',
-            color: WHITE,
           }}
         >
-          <ArrowLeft size={16} style={{ display: 'block', flexShrink: 0 }} />
-          <span
+          <button
+            type="button"
+            onClick={onBack}
+            {...helpProps(HELP.backToChain)}
             style={{
-              fontFamily: FONT_MONO,
-              fontSize: '16rem',
-              fontWeight: 400,
-              textTransform: 'uppercase',
-              lineHeight: 1.4,
+              display: 'flex',
+              alignItems: 'center',
+              gap: '16rem',
+              flexShrink: 0,
+              background: 'transparent',
+              border: 'none',
+              outline: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              color: WHITE,
             }}
           >
-            Block
-          </span>
-        </button>
+            <ArrowLeft size={16} style={{ display: 'block', flexShrink: 0 }} />
+            <span
+              style={{
+                fontFamily: FONT_MONO,
+                fontSize: '16rem',
+                fontWeight: 400,
+                textTransform: 'uppercase',
+                lineHeight: 1.4,
+              }}
+            >
+              Block
+            </span>
+          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8rem' }}>
+            <ChromeIconButton
+              help={HELP.prevBlock}
+              onClick={onPrev}
+              disabled={!hasPrev || isSwitchingModel}
+            >
+              <ChevronLeft />
+            </ChromeIconButton>
+            <ChromeIconButton
+              help={HELP.nextBlock}
+              onClick={onNext}
+              disabled={!hasNext || isSwitchingModel}
+            >
+              <ChevronRight />
+            </ChromeIconButton>
+          </div>
+        </div>
 
         <div
           style={{
@@ -670,6 +733,29 @@ export const ChainBlock: React.FC<ChainBlockProps> = ({
                 </span>
               )}
             </div>
+
+            {/* Orientation cue while the EQ view is open (issue #83 follow-up):
+              the EQ body looks identical block to block, and PrevNext swaps
+              which block it's showing without a mount/remount, so without
+              this a step left no visible sign of which block you're now on.
+              The non-EQ body already shows the title prominently, so this
+              only needs to appear here. Reads straight off the `tone` prop,
+              so it updates on every step automatically - no extra state. */}
+            {showEq && (
+              <span
+                style={{
+                  fontSize: '13rem',
+                  color: GRAY,
+                  fontWeight: 400,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  minWidth: 0,
+                }}
+              >
+                {tone.title}
+              </span>
+            )}
 
             {/* Right cluster: EQ submenu (pill when open), info, then share/swap/trash.
               EQ stays rightmost in the submenu so opening grows left only.

--- a/ui/src/components/ChainView.tsx
+++ b/ui/src/components/ChainView.tsx
@@ -453,6 +453,22 @@ export const ChainView: React.FC<ChainViewProps> = ({
       ? chain
       : (chainRight ?? []);
     const detailIndex = detailLane.findIndex((item) => item.blockId === detailBlock.blockId);
+
+    // Prev/Next (issue #83): step within this same lane only — a branch taps
+    // the signal into the other lane but never reorders or merges the two
+    // arrays, so "next" staying lane-local is correct in stereo too, branched
+    // or not. Skips insert slots (nothing to open there); clamps at the
+    // lane's ends rather than wrapping.
+    const stepBlock = (dir: 1 | -1): ToneBlock | null => {
+      for (let i = detailIndex + dir; i >= 0 && i < detailLane.length; i += dir) {
+        const item = detailLane[i];
+        if (!isInsertSlot(item)) return item;
+      }
+      return null;
+    };
+    const prevBlock = stepBlock(-1);
+    const nextBlock = stepBlock(1);
+
     const namDownstream = detailLane
       .slice(detailIndex + 1)
       .some(
@@ -486,6 +502,10 @@ export const ChainView: React.FC<ChainViewProps> = ({
             pendingScrollTargetRef.current = { kind: 'id', blockId: detailBlock.blockId };
             setDetailBlockId(null);
           }}
+          hasPrev={prevBlock != null}
+          onPrev={() => prevBlock && setDetailBlockId(prevBlock.blockId)}
+          hasNext={nextBlock != null}
+          onNext={() => nextBlock && setDetailBlockId(nextBlock.blockId)}
           onFillToFaceplate={onFillToFaceplate}
         />
       </div>

--- a/ui/src/components/ChainView.tsx
+++ b/ui/src/components/ChainView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { getUiScale, rem } from '../hooks/useUiScale';
 import { DragDropProvider } from '@dnd-kit/react';
 import { isSortable } from '@dnd-kit/react/sortable';
@@ -101,6 +101,12 @@ const sensors: Sensors = [
 ];
 
 type Lanes = Record<ChainSide, ChainItem[]>;
+
+/** Scroll-restore target queued for the next return to the gallery: either a
+    blockId (explicit Back — the block still exists, see onBack) or a lane +
+    index (the open block vanished out from under us — trash, undo, redo...
+    see the scroll-restore effect in ChainView). */
+type PendingScroll = { kind: 'id'; blockId: string } | { kind: 'index'; side: ChainSide; index: number };
 
 /** Id of the ⌥-duplicate stand-in: the inert copy of the dragged block that
     holds its home slot while the standard drag machinery runs untouched. */
@@ -324,14 +330,120 @@ export const ChainView: React.FC<ChainViewProps> = ({
   };
 
   // Resolve the detail block across both lanes; it can disappear underneath
-  // us (undo, trash from the detail header), in which case we fall back to
-  // the gallery.
+  // us (undo, trash from the detail header, redo of a delete...), in which
+  // case we fall back to the gallery.
   const detailBlock =
     detailBlockId != null
       ? ([...chain, ...(chainRight ?? [])].find(
           (item): item is ToneBlock => !isInsertSlot(item) && item.blockId === detailBlockId
         ) ?? null)
       : null;
+
+  const stereo = chainRight != null;
+  const tileSize = stereo ? STEREO_TILE_SIZE : TILE_SIZE;
+
+  // Branched layout: the branch lane starts at the trunk's tap gap, so its
+  // row is indented past the whole trunk prefix (matching the signal flow:
+  // its input *is* that prefix's output). Resolved against the optimistic
+  // lane state; a stale tap id (mid-resync after the tapped block moved)
+  // renders as independent lanes until native's cleared state arrives.
+  // Computed here (ahead of the detail-view early return) because the
+  // scroll-restore effect below needs it too, and hooks can't follow a
+  // conditional return.
+  const branchLayout = (() => {
+    if (!stereo || branch == null) return null;
+    const tapIndex = lanes[branch.side].findIndex((i) => i.blockId === branch.afterBlockId);
+    if (tapIndex === -1) return null;
+    return {
+      trunkSide: branch.side,
+      indentPx: (tapIndex + 1) * (tileSize + TILE_GAP),
+      tapGapX: gapCenterX(tapIndex + 1, tileSize),
+    };
+  })();
+
+  // Scroll-restore target queued for the next return to the gallery; consumed
+  // synchronously by the effect below, so no render should ever observe it.
+  const pendingScrollTargetRef = useRef<PendingScroll | null>(null);
+
+  // The open detail block's last-known lane + index, kept fresh on every
+  // render it's still resolvable (a plain ref write during render — cheap,
+  // and there's no cleaner hook for "remember the last real value before a
+  // prop-driven change replaces it"). If the block then vanishes from
+  // underneath us, there's nothing left to look it up by id, so the effect
+  // below falls back to this instead.
+  const lastDetailPositionRef = useRef<{ side: ChainSide; index: number } | null>(null);
+  if (detailBlock != null) {
+    const side = laneOf(detailBlock.blockId);
+    const index =
+      side != null ? lanes[side].findIndex((i) => i.blockId === detailBlock.blockId) : -1;
+    if (side != null && index !== -1) lastDetailPositionRef.current = { side, index };
+  }
+
+  const galleryScrollElRef = useRef<HTMLDivElement | null>(null);
+  const setGalleryScrollEl = useCallback(
+    (el: HTMLDivElement | null) => {
+      wheelScrollRef(el);
+      galleryScrollElRef.current = el;
+    },
+    [wheelScrollRef]
+  );
+
+  // Center the just-closed (or just-vanished) block's tile instead of
+  // leaving the gallery scrolled to wherever a freshly mounted scroller
+  // defaults (issue #82): the gallery's scroll div unmounts while the detail
+  // takeover is open (see useHorizontalWheelScroll), so there's no prior
+  // scrollLeft to restore. Recomputing the tile's position (rather than
+  // replaying a raw offset) also survives the chain reshaping while the
+  // takeover was open (the block moved, or a preceding block was
+  // deleted/inserted).
+  useLayoutEffect(() => {
+    if (detailBlock != null) return;
+
+    // detailBlockId only reaches null a step ahead of us, via onBack itself
+    // (which seeds pendingScrollTargetRef in the same breath it clears this
+    // state). Landing here with detailBlockId still set means the block the
+    // takeover was open on disappeared out from under us instead — trash,
+    // undo, redo, anything native-initiated — so there's no explicit Back to
+    // rely on: fall back to its last known position, and drop the now-
+    // dangling id (otherwise it lingers in state and sessionStorage forever).
+    if (detailBlockId != null) {
+      setDetailBlockId(null);
+      if (lastDetailPositionRef.current != null) {
+        pendingScrollTargetRef.current = { kind: 'index', ...lastDetailPositionRef.current };
+      }
+    }
+
+    const target = pendingScrollTargetRef.current;
+    const el = galleryScrollElRef.current;
+    if (target == null || el == null) return;
+    pendingScrollTargetRef.current = null;
+
+    let side: ChainSide;
+    let index: number;
+    if (target.kind === 'id') {
+      const resolvedSide = laneOf(target.blockId);
+      if (resolvedSide == null) return;
+      side = resolvedSide;
+      index = lanes[resolvedSide].findIndex((i) => i.blockId === target.blockId);
+      if (index === -1) return;
+    } else {
+      side = target.side;
+      // The vacated slot may now be past the end (e.g. the removed block was
+      // the last real one, leaving only trailing insert slots).
+      index = Math.min(target.index, lanes[side].length - 1);
+      if (index < 0) return;
+    }
+
+    const indent =
+      branchLayout != null && side !== branchLayout.trunkSide ? branchLayout.indentPx : 0;
+    const centerDesignPx = EDGE_FADE_WIDTH + indent + index * (tileSize + TILE_GAP) + tileSize / 2;
+    const centerPx = centerDesignPx * getUiScale();
+    const max = el.scrollWidth - el.clientWidth;
+    el.scrollLeft = Math.max(0, Math.min(max, centerPx - el.clientWidth / 2));
+    // laneOf reads the same `lanes` this effect depends on; branchLayout and
+    // tileSize are derived from lanes/branch/chainRight above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailBlock, detailBlockId, lanes, branchLayout, tileSize]);
 
   if (detailBlock) {
     // Another enabled+loaded NAM after this block in its lane. This mirrors the
@@ -370,31 +482,15 @@ export const ChainView: React.FC<ChainViewProps> = ({
           namDownstream={namDownstream}
           sampleRate={sampleRate}
           namSlimSizeDefault={namSlimSizeDefault}
-          onBack={() => setDetailBlockId(null)}
+          onBack={() => {
+            pendingScrollTargetRef.current = { kind: 'id', blockId: detailBlock.blockId };
+            setDetailBlockId(null);
+          }}
           onFillToFaceplate={onFillToFaceplate}
         />
       </div>
     );
   }
-
-  const stereo = chainRight != null;
-  const tileSize = stereo ? STEREO_TILE_SIZE : TILE_SIZE;
-
-  // Branched layout: the branch lane starts at the trunk's tap gap, so its
-  // row is indented past the whole trunk prefix (matching the signal flow:
-  // its input *is* that prefix's output). Resolved against the optimistic
-  // lane state; a stale tap id (mid-resync after the tapped block moved)
-  // renders as independent lanes until native's cleared state arrives.
-  const branchLayout = (() => {
-    if (!stereo || branch == null) return null;
-    const tapIndex = lanes[branch.side].findIndex((i) => i.blockId === branch.afterBlockId);
-    if (tapIndex === -1) return null;
-    return {
-      trunkSide: branch.side,
-      indentPx: (tapIndex + 1) * (tileSize + TILE_GAP),
-      tapGapX: gapCenterX(tapIndex + 1, tileSize),
-    };
-  })();
 
   const lane = (side: ChainSide) => (
     <div
@@ -468,7 +564,7 @@ export const ChainView: React.FC<ChainViewProps> = ({
             </span>
           )}
           <div
-            ref={wheelScrollRef}
+            ref={setGalleryScrollEl}
             className="hide-scrollbar"
             style={{
               flex: 1,

--- a/ui/src/components/helpText.ts
+++ b/ui/src/components/helpText.ts
@@ -255,6 +255,8 @@ export const HELP = {
   shareTone: 'Share: copy TONE3000 link.',
   modelSelectSignedOut: 'Models: sign in to TONE3000 to switch models.',
   backToChain: 'Back: chain overview.',
+  prevBlock: 'Previous: the block before this one.',
+  nextBlock: 'Next: the block after this one.',
 
   // EQ editor
   eqFader: `Band Fader: gain, ±15 dB. ${shift('drag')}: fine · double-click / ${alt(


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/516a4c43-2bfd-48b3-8065-63489ec8fe14



- Adds Prev/Next chevrons (and Left/Right arrow key shortcuts) to the
  block detail header so you can step through adjacent blocks in the
  same lane without closing back to the chain gallery each time.
- Reuses the existing `detailBlockId` prop-swap mechanism already
  exercised by swap-tone (same blockId, new tone) rather than any new
  unmount/remount boundary, so it doesn't touch #82/#114's scroll-restore
  work at all.
- Stepping is lane-local and skips insert slots, clamped at the lane's
  ends (no wraparound); a branch only taps the signal into the other
  lane, it never reorders or merges the two arrays, so this is correct
  in stereo too regardless of branching.
- Both chevrons and the arrow-key shortcut disable while a model switch
  is in flight (`switchModel` has no cancel handle, so a step mid-switch
  is ignored rather than left to race), and the arrow listener ignores
  keydowns while an input/textarea/select/editable element has focus so
  it doesn't fight normal typing or dropdown navigation.
- `showEq`/`eqView` deliberately survive a step (not reset) so you can
  compare EQ curves block to block — but the EQ body otherwise looks
  identical regardless of which block it's showing, so a step left no
  visible sign of which block you landed on. Fix: a small tone-title
  label in the shared card header, shown only while the EQ view is open
  (the non-EQ body already shows the title prominently). It reads
  straight off the `tone` prop, so it updates automatically on every
  step with no new state or effect.

**Depends on #115** (issue #82's scroll-restore fix): this branch is
based on `feature/chain-scroll-restore` rather than `main` directly,
since this change extends the exact `onBack` code path #115 rewrote.
Until #115 merges, this PR's diff includes its commit too — that's
expected for a stacked PR, not a mistake.

Fixes #83

## Test plan

- [x] `./script/test-dsp.sh` — 140/140 tests pass on this branch
- [x] `tsc -b` / `eslint` clean on the changed files
- [x] Full plugin build (Release, Standalone) succeeds
- [x] Manually verified in a freshly built Standalone: Prev/Next chevrons
      and arrow keys step correctly, disable at lane boundaries, and the
      EQ header shows the current block's title while stepping

🤖 Generated with [Claude Code](https://claude.com/claude-code)