### PR TITLE
Experimental: Apple Silicon planar A2 integration for lower CPU usage

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "plugin/NeuralAmpModelerCore"]
 	path = plugin/NeuralAmpModelerCore
-	url = https://github.com/sdatkinson/NeuralAmpModelerCore.git
+	url = https://github.com/honkkis/NeuralAmpModelerCore.git
 	branch = main
 [submodule "plugin/AudioDSPTools"]
 	path = plugin/AudioDSPTools

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "plugin/NeuralAmpModelerCore"]
 	path = plugin/NeuralAmpModelerCore
-	url = https://github.com/honkkis/NeuralAmpModelerCore.git
-	branch = main
+	url = https://github.com/rikkus/OptimisationWorkOnNeuralAmpModelerCore.git
+	branch = apple-silicon-a2-planar
 [submodule "plugin/AudioDSPTools"]
 	path = plugin/AudioDSPTools
 	url = https://github.com/sdatkinson/AudioDSPTools.git

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(NAM STATIC
     ${NAM_SRC}/ring_buffer.cpp
     ${NAM_SRC}/util.cpp
     ${NAM_SRC}/wavenet/a2_fast.cpp
+    ${NAM_SRC}/wavenet/a2_planar.cpp
     ${NAM_SRC}/wavenet/model.cpp
     ${NAM_SRC}/wavenet/slimmable.cpp
 )

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 # compile with MSVC (GCC/Clang-only flags, M_PI, POSIX dlfcn.h in run_tests),
 # and each one recompiles all NAM sources, wasting CI time. Keep them out of
 # the default build; build explicitly if needed: cmake --build build --target benchmodel
-foreach(_nam_tool tools loadmodel benchmodel render benchmodel_bufsize bench_a2_fast run_tests)
+foreach(_nam_tool tools loadmodel benchmodel render benchmodel_bufsize bench_a2_fast bench_a2_planar bench_linear run_tests)
     if(TARGET ${_nam_tool})
         set_target_properties(${_nam_tool} PROPERTIES EXCLUDE_FROM_ALL TRUE)
     endif()
@@ -119,8 +119,11 @@ add_library(NAM STATIC
     ${NAM_SRC}/convnet.cpp
     ${NAM_SRC}/dsp.cpp
     ${NAM_SRC}/get_dsp.cpp
+    ${NAM_SRC}/linear.cpp
     ${NAM_SRC}/lstm.cpp
+    ${NAM_SRC}/nam_file.cpp
     ${NAM_SRC}/ring_buffer.cpp
+    ${NAM_SRC}/sequential.cpp
     ${NAM_SRC}/util.cpp
     ${NAM_SRC}/wavenet/a2_fast.cpp
     ${NAM_SRC}/wavenet/a2_planar.cpp


### PR DESCRIPTION
This is an experimental integration of Rik Hemsley's planar NEON A2 work from NeuralAmpModelerCore PR #313:

https://github.com/sdatkinson/NeuralAmpModelerCore/pull/313

TONE3000's phase-interleaved oversampling looks like a particularly good fit for it. At 4x, an A2 model is split across four native-rate model instances, so with 32- or 64-sample host buffers each instance runs at the same small block sizes where the planar path performs well.

I backported the PR #313 changes to the Core revision currently used by TONE3000 and added `a2_planar.cpp` to TONE3000's explicit NAM source list. The Core submodule URL in this branch points temporarily to my fork because PR #313 has not been merged upstream yet.

Testing on an Apple M1:

- Core planar tests pass and remain bit-identical to the existing A2 fast path.
- A2 standard / 8-channel: 2.666x at 32 frames and 2.477x at 64 frames.
- A2 nano / 3-channel: 2.171x at 32 frames and 1.992x at 64 frames.
- In TONE3000 itself, using an A2 model with 4x oversampling in REAPER, I see roughly 50% lower CPU.

I think this is worth trying as a performance experiment, especially for Apple Silicon users.

I wouldn't treat the current submodule pin as the final form. If the Core change lands upstream, TONE3000 can move back to the normal upstream Core dependency.

Credit for the planar NEON implementation and the underlying optimization work goes to Rik Hemsley (`rikkus`) in NeuralAmpModelerCore PR #313.
