### PR TITLE
ui(fix): keep the chain gallery's scroll position across takeovers

### DIFF
--- a/ui/src/components/ChainView.tsx
+++ b/ui/src/components/ChainView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { getUiScale, rem } from '../hooks/useUiScale';
 import { DragDropProvider } from '@dnd-kit/react';
 import { isSortable } from '@dnd-kit/react/sortable';
@@ -51,6 +51,14 @@ import { isInsertSlot } from '../types/chain';
  * Cleared from Plugin on preset load so a remount lands on the gallery.
  */
 export const DETAIL_BLOCK_STORAGE_KEY = 't3k.detailBlockId';
+
+/**
+ * Gallery scroll offset in design px, persisted for the same reason: the
+ * scroller unmounts under the detail takeover, the tone browser, and the
+ * tuner, and coming back should land where the user left off (issue #82).
+ * Cleared from Plugin on preset load so a new chain starts at the left edge.
+ */
+export const CHAIN_SCROLL_STORAGE_KEY = 't3k.chainScroll';
 
 interface ChainViewProps {
   /** Left lane (the only lane in mono mode). */
@@ -119,6 +127,30 @@ export const ChainView: React.FC<ChainViewProps> = ({
 }) => {
   const actions = useChainActions();
   const wheelScrollRef = useHorizontalWheelScroll<HTMLDivElement>();
+  // One callback ref wires the scroller: it restores the saved offset before
+  // first paint, persists it as the user scrolls, and attaches the wheel
+  // hook's panning. The hook returns a cleanup (and once a ref callback
+  // returns a cleanup React never calls it with null), so it must be
+  // forwarded here, not swallowed: StrictMode's dev double-attach would
+  // stack a second wheel listener.
+  const galleryScrollRef = useCallback(
+    (el: HTMLDivElement) => {
+      // Stored in design px so a window rescale between visits lands in the
+      // same place; an offset past the end (the chain shrank) clamps on
+      // assignment.
+      const saved = Number(sessionStorage.getItem(CHAIN_SCROLL_STORAGE_KEY));
+      if (saved > 0) el.scrollLeft = saved * getUiScale();
+      const save = () =>
+        sessionStorage.setItem(CHAIN_SCROLL_STORAGE_KEY, String(el.scrollLeft / getUiScale()));
+      el.addEventListener('scroll', save, { passive: true });
+      const wheelCleanup = wheelScrollRef(el);
+      return () => {
+        el.removeEventListener('scroll', save);
+        if (typeof wheelCleanup === 'function') wheelCleanup();
+      };
+    },
+    [wheelScrollRef]
+  );
   // Persisted so the detail takeover survives this component unmounting: a
   // swap from the detail view opens the tone browser (which replaces the whole
   // chain view, and may bounce through the tone3000.com OAuth redirect). The
@@ -333,6 +365,12 @@ export const ChainView: React.FC<ChainViewProps> = ({
         ) ?? null)
       : null;
 
+  // Drop an id whose block vanished: left alone it lingers in state and
+  // sessionStorage and could reopen a dead detail view later.
+  useEffect(() => {
+    if (detailBlockId != null && detailBlock == null) setDetailBlockId(null);
+  }, [detailBlockId, detailBlock]);
+
   if (detailBlock) {
     // Another enabled+loaded NAM after this block in its lane. This mirrors the
     // DSP's lastNamIndex scan (Processor.cpp): with calibration on, such a
@@ -468,7 +506,7 @@ export const ChainView: React.FC<ChainViewProps> = ({
             </span>
           )}
           <div
-            ref={wheelScrollRef}
+            ref={galleryScrollRef}
             className="hide-scrollbar"
             style={{
               flex: 1,

--- a/ui/src/components/Plugin.tsx
+++ b/ui/src/components/Plugin.tsx
@@ -12,7 +12,7 @@ import { useToneLoadFlow } from '../hooks/useToneLoadFlow';
 import { useUpdateNotice } from '../hooks/useUpdateNotice';
 import { useUiScale, DESIGN_WIDTH, DESIGN_HEIGHT } from '../hooks/useUiScale';
 import { shouldRestoreToneBrowser } from '../hooks/useT3kSelect';
-import { ChainView, DETAIL_BLOCK_STORAGE_KEY } from './ChainView';
+import { CHAIN_SCROLL_STORAGE_KEY, ChainView, DETAIL_BLOCK_STORAGE_KEY } from './ChainView';
 import { Faceplate, PLATE_HEIGHT } from './Faceplate';
 import { HintBar, HINT_HEIGHT } from './HintBar';
 import { ToastProvider } from './Toast';
@@ -208,6 +208,7 @@ export const Plugin: React.FC = () => {
           setShowToneBrowser(false);
         }
         sessionStorage.removeItem(DETAIL_BLOCK_STORAGE_KEY);
+        sessionStorage.removeItem(CHAIN_SCROLL_STORAGE_KEY);
         setReturnToGallery((n) => n + 1);
         return fn(...args);
       },


### PR DESCRIPTION
## Summary

Supersedes #115. Fixes #82
Co-authored-by: Plum Audio <31374448+Shayshez@users.noreply.github.com>

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
