### PR TITLE
fix(linux): enable JACK backend so PipeWire keeps the interface (#125)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,6 +107,7 @@ jobs:
             libgtk-3-dev \
             libwebkit2gtk-4.1-dev \
             libasound2-dev \
+            libjack-jackd2-dev \
             libcurl4-openssl-dev \
             libfreetype6-dev \
             libx11-dev \

--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ sudo zypper install libwebkit2gtk-4_1-0   # openSUSE
 The release tarball's `install.sh` checks for these automatically
 (`./install.sh --check` to verify without installing).
 
+Optional: a JACK server. The standalone's Audio Driver picker offers JACK
+next to ALSA (libjack is loaded at runtime; without a server the driver just
+lists no devices). On PipeWire systems (`pipewire-jack`), JACK is the
+recommended driver: the ALSA driver's raw hardware devices ("Direct hardware
+device without any conversions") open the card exclusively, which takes the
+whole interface away from every other app while the standalone runs. The
+JACK driver shares it.
+
 ## Audio processing
 
 The plugin is a JUCE processor running a chain of NAM and IR blocks, anchored

--- a/plugin/CMakeLists.txt
+++ b/plugin/CMakeLists.txt
@@ -482,6 +482,25 @@ else()
     target_compile_definitions(${PROJECT_NAME} PUBLIC JUCE_USE_CURL=0)
 endif()
 
+# Linux: compile JUCE's JACK backend into the standalone's device-type list
+# (the settings UI grows an "Audio Driver" picker automatically when more
+# than one backend exists). JUCE's ALSA backend opens the selected card
+# directly and exclusively: picking a USB interface's raw device steals the
+# whole card from PipeWire/PulseAudio, killing its other channels for every
+# other app until the audio server recovers (issue #125 - a Scarlett Solo's
+# mic dying system-wide while the app holds the guitar channel). The JACK
+# backend connects as a client instead, so on any PipeWire system
+# (pipewire-jack) or real JACK server the interface stays shared. libjack is
+# dlopened at runtime (libjack.so.0, JackNoStartServer) like curl/WebKit
+# above, so this adds no runtime dependency: without a JACK server the
+# driver just lists no devices. Build hosts need the JACK headers
+# (libjack-jackd2-dev; CI installs it). The JACK client name defaults to
+# JucePlugin_Name ("TONE3000"). Gated on NOT HEADLESS so embedded
+# toolchains don't grow a header dependency.
+if (UNIX AND NOT APPLE AND NOT HEADLESS)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC JUCE_JACK=1)
+endif()
+
 # Linux: stay on the classic core-X11 input path. JUCE 9 rewrote Linux input
 # around XInput2 (per-window XI2 registration, core ButtonPress/Motion events
 # discarded when XI2 >= 2.2 is present, which is every modern system). A missed


### PR DESCRIPTION
## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
