### PR TITLE
fix(windows): link the MSVC runtime statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,14 @@ endif()
 set(CMAKE_CXX_STANDARD 20)
 set(LIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)
 
+# Windows: link the MSVC runtime statically (/MT). The plugin formats load
+# into host processes we don't control and the installer ships no vc_redist,
+# so a dynamically linked runtime fails on any machine without the VC++
+# Redistributable installed ("MSVCP140.dll was not found", #129). Set before
+# the CPM packages so every target in the tree links the same runtime;
+# ignored on non-MSVC platforms.
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # Download CPM package manager
 include(cmake/cpm.cmake) 
 
@@ -918,7 +926,6 @@ CPMAddPackage(
     SOURCE_DIR ${LIB_DIR}/googletest
     OPTIONS
         "INSTALL_GTEST OFF"
-        "gtest_force_shared_crt ON"
 )
 
 enable_testing() # Allow running build tests


### PR DESCRIPTION
All Windows artefacts were built with CMake's default /MD and neither the installer nor the exe ships the VC++ Redistributable, so any machine without it fails at launch with "MSVCP140.dll was not found" (standalone dialog; VST3/CLAP silently skipped by DAW scanners). CI never sees it because the runners have Visual Studio installed.

Static linking is the audio-plugin norm: the formats load into arbitrary host processes, so the runtime can't depend on what's installed there. CMAKE_MSVC_RUNTIME_LIBRARY covers every target in the tree (CMP0091 is NEW under the CMake 3.22 floor). gtest_force_shared_crt is dropped: it only rewrites /MD in the legacy flag variables, which the NEW policy leaves empty, so it was already inert.

Fixes #129

## Summary

<!-- Why this exists. Keep it small: no speculative fallbacks, no dead code. -->

## Test plan

CI does not run on pull requests. A maintainer can dispatch **Build Plugin** from the Actions tab when they want a full signed build. Run the local checks this PR can break:

- [ ] DSP: `./script/test-dsp.sh` (or N/A: no audio/chain/state change)
- [ ] UI: `cd ui && npm run lint && npm run build` (or N/A: no `ui/` change)
- [ ] Host validators, if you touched the processor, editor, or plugin wrappers: `./script/validate-plugin.sh` ([pluginval](https://github.com/Tracktion/pluginval) strictness 10 for VST3/AU, clap-validator, lv2lint). AAX and Standalone are skipped by that script.
- [ ] Host smoke (DAW + format + sample rate), if this is user-visible

If you changed DSP behavior on purpose, update the GoogleTest in the same commit and say why.

## Compatibility

These are contracts from the first public release. Leave unchecked only if this PR does not touch that surface.

- [ ] AU parameter version hints in `Processor.cpp` are not reused or renumbered
- [ ] LV2 URI and CLAP ID in `plugin/CMakeLists.txt` are unchanged
- [ ] State format is unchanged, or `kStateSchemaVersion` is bumped and the old tree is handled explicitly
- [ ] README / `plugin/docs/` updated if the public build or behavior changed
